### PR TITLE
Escape repo details

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,6 +4,22 @@ const languageFilter = document.getElementById('languageFilter');
 const tagFilter = document.getElementById('tagFilter');
 const sortBy = document.getElementById('sortBy');
 
+// Escape HTML to avoid injecting markup from repo data
+function escapeHtml(unsafe) {
+  return String(unsafe).replace(/[&<>"'{}]/g, match => {
+    const map = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#039;',
+      '{': '&#123;',
+      '}': '&#125;'
+    };
+    return map[match];
+  });
+}
+
 let repos = [];
 let languages = new Set();
 let tags = new Set();
@@ -22,9 +38,15 @@ fetch('data.json')
 
 function populateFilters() {
   languageFilter.innerHTML = '<option value="all">All Languages</option>' +
-    Array.from(languages).sort().map(l => `<option value="${l}">${l}</option>`).join('');
+    Array.from(languages)
+      .sort()
+      .map(l => `<option value="${escapeHtml(l)}">${escapeHtml(l)}</option>`)
+      .join('');
   tagFilter.innerHTML = '<option value="all">All Tags</option>' +
-    Array.from(tags).sort().map(t => `<option value="${t}">${t}</option>`).join('');
+    Array.from(tags)
+      .sort()
+      .map(t => `<option value="${escapeHtml(t)}">${escapeHtml(t)}</option>`)
+      .join('');
 }
 
 function render() {
@@ -70,9 +92,9 @@ function repoCard(repo){
   const langs = (repo.languages || []).map(l => `${l.language}`).join(', ');
   const topics = (repo.topics || []).join(', ');
   return `<div class="repo-card">
-    <h3><a href="${repo.url}" target="_blank">${repo.name}</a></h3>
-    <p><strong>Author:</strong> ${repo.author}</p>
-    <p><strong>Description:</strong> ${repo.description}</p>
+    <h3><a href="${repo.url}" target="_blank">${escapeHtml(repo.name)}</a></h3>
+    <p><strong>Author:</strong> ${escapeHtml(repo.author)}</p>
+    <p><strong>Description:</strong> ${escapeHtml(repo.description)}</p>
     <div class="metrics">
       <div class="metric"><i class="fa fa-star"></i> ${repo.stars}</div>
       <div class="metric"><i class="fa fa-code-branch"></i> ${repo.forks}</div>
@@ -80,7 +102,7 @@ function repoCard(repo){
       <div class="metric"><i class="fa fa-calendar"></i> ${repo.last_updated}</div>
     </div>
     <div class="languages">${langs}</div>
-    <div class="topics">${topics || 'None'}</div>
+    <div class="topics">${escapeHtml(topics) || 'None'}</div>
   </div>`;
 }
 


### PR DESCRIPTION
## Summary
- sanitize repo data when rendering in the browser
- HTML-escape repo names, authors, descriptions and topics

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node - <<'NODE' ...` (verify render string)


------
https://chatgpt.com/codex/tasks/task_e_685d9b2d41188320a004e501260a74fb