### PR TITLE
Add header with dynamic badges

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,26 @@
     <link rel="stylesheet" href="main.css">
 </head>
 <body>
-    <h1 id="pageTitle">Git Stars</h1>
+    <header class="main-header">
+        <div class="left-group capsule">
+            <i class="fa-brands fa-github"></i>
+            <span id="repoCountBadge" class="badge">0</span>
+            <span class="title">GitStars</span>
+        </div>
+        <div class="center-group">
+            <button class="icon-btn"><i class="fa-solid fa-chart-column"></i></button>
+            <button class="icon-btn"><i class="fa-solid fa-book"></i></button>
+            <button class="icon-btn"><i class="fa-solid fa-comments"></i></button>
+            <button class="icon-btn"><i class="fa-solid fa-newspaper"></i></button>
+        </div>
+        <div class="right-group">
+            <div class="logs-container">
+                <i class="fa-solid fa-clipboard-list"></i>
+                <span id="logsCountBadge" class="badge">0</span>
+            </div>
+            <i class="fa-solid fa-gear"></i>
+        </div>
+    </header>
     <div id="reposContainer"></div>
     <div class="filters">
         <input type="text" id="searchInput" placeholder="Search...">

--- a/main.css
+++ b/main.css
@@ -8,17 +8,80 @@ body {
     padding: 0;
 }
 
-/* Fixed page title */
-#pageTitle {
+/* Header */
+.main-header {
     position: fixed;
-    top: 10px;
-    left: 10px;
-    margin: 0;
-    padding: 5px 10px;
-    font-weight: bold;
-    color: #000;
-    background: rgba(255,255,255,0.8);
+    top: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 20px;
+    background: rgba(255, 255, 255, 0.6);
+    backdrop-filter: blur(10px);
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
     z-index: 1000;
+}
+
+.main-header .left-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.main-header .left-group.capsule {
+    padding: 6px 12px;
+    background: rgba(255, 255, 255, 0.8);
+    border-radius: 999px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+}
+
+.main-header .center-group {
+    display: flex;
+    gap: 8px;
+}
+
+.icon-btn {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.8);
+    border: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: background 0.2s, transform 0.2s;
+}
+
+.icon-btn:hover {
+    background: rgba(255, 255, 255, 1);
+    transform: scale(1.1);
+}
+
+.badge {
+    background: #ff4757;
+    color: #fff;
+    border-radius: 12px;
+    padding: 2px 6px;
+    font-size: 0.75em;
+}
+
+.right-group {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.logs-container {
+    position: relative;
+}
+
+.logs-container .badge {
+    position: absolute;
+    top: -6px;
+    right: -10px;
 }
 
 /* Repo grid */
@@ -113,9 +176,6 @@ body {
 }
 
 @media (max-width: 600px) {
-    #pageTitle {
-        font-size: 1.2em;
-    }
     .filters {
         flex-direction: column;
         align-items: center;

--- a/main.js
+++ b/main.js
@@ -3,6 +3,8 @@ const searchInput = document.getElementById('searchInput');
 const languageFilter = document.getElementById('languageFilter');
 const tagFilter = document.getElementById('tagFilter');
 const sortBy = document.getElementById('sortBy');
+const repoCountBadge = document.getElementById('repoCountBadge');
+const logsCountBadge = document.getElementById('logsCountBadge');
 
 let repos = [];
 let languages = new Set();
@@ -12,6 +14,9 @@ fetch('data.json')
   .then(r => r.json())
   .then(data => {
     repos = data;
+    repoCountBadge.textContent = repos.length;
+    const logs = JSON.parse(localStorage.getItem('logs') || '[]');
+    logsCountBadge.textContent = logs.length;
     repos.forEach(r => {
       (r.languages || []).forEach(l => languages.add(l.language));
       (r.topics || []).forEach(t => tags.add(t));


### PR DESCRIPTION
## Summary
- design interactive header with icon groups and badges
- apply frosted glass styling for the new header
- update JS to fill badge counts from `data.json` and local storage

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d9ae35eb08320a3e3a9238c9e7c2f