### PR TITLE
Fix star count and header layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,9 +21,12 @@
     </div>
     <div class="right-group">
       <div class="logs-container" title="Logs">
-        <i class="fa fa-list"></i>
+        <a id="logsIcon" href="logs.html"><i class="fa fa-list"></i></a>
         <span id="logCount" class="badge">0</span>
       </div>
+      <i id="summarizeIcon" class="fa fa-comment-dots action-icon" title="Summarize"></i>
+      <i id="tagIcon" class="fa fa-tags action-icon" title="Tag"></i>
+      <i id="rateIcon" class="fa fa-star-half-stroke action-icon" title="Rate"></i>
       <button class="icon-btn" id="settingsBtn" title="Settings"><i class="fa fa-cog"></i></button>
     </div>
   </header>
@@ -32,12 +35,6 @@
 
   <div id="errorMessage" class="error"></div>
 
-  <div id="actionHeader" class="header-actions">
-    <i id="summarizeIcon" class="fa fa-comment-dots action-icon" title="Summarize"></i>
-    <i id="tagIcon" class="fa fa-tags action-icon" title="Tag"></i>
-    <i id="rateIcon" class="fa fa-star-half-stroke action-icon" title="Rate"></i>
-    <a id="logsIcon" href="logs.html" title="Logs"><i class="fa fa-list action-icon"></i></a>
-  </div>
 
   <div id="reposContainer"></div>
 

--- a/main.css
+++ b/main.css
@@ -6,15 +6,15 @@ body {
     line-height: 1.6;
     margin: 0;
     padding: 0;
-    padding-top: 60px; /* space for header */
+    padding-top: 100px; /* space for header */
 }
 
 /* Header */
 .main-header {
     position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
+    top: 12px;
+    left: 12px;
+    right: 12px;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -22,6 +22,7 @@ body {
     background: rgba(255, 255, 255, 0.6);
     backdrop-filter: blur(10px);
     box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+    border-radius: 999px;
     z-index: 1000;
 }
 
@@ -47,12 +48,12 @@ body {
 
 .main-header .center-group {
     display: flex;
-    gap: 8px;
+    gap: 12px;
 }
 
 .icon-btn {
-    width: 32px;
-    height: 32px;
+    width: 64px;
+    height: 64px;
     border-radius: 50%;
     background: rgba(255, 255, 255, 0.8);
     border: none;
@@ -61,6 +62,7 @@ body {
     justify-content: center;
     cursor: pointer;
     transition: background 0.2s, transform 0.2s;
+    font-size: 2em;
 }
 
 .icon-btn:hover {
@@ -88,8 +90,8 @@ body {
 
 .logs-container .badge {
     position: absolute;
-    top: -6px;
-    right: -10px;
+    top: -4px;
+    right: -4px;
 
 }
 
@@ -216,26 +218,15 @@ select:focus {
 }
 
 /* Header action icons */
-.header-actions {
-    position: fixed;
-    top: 10px;
-    right: 10px;
-    display: flex;
-    gap: 10px;
-    z-index: 1000;
-}
-
 .action-icon {
     cursor: pointer;
     background: rgba(255,255,255,0.8);
     padding: 5px;
     border-radius: 4px;
     color: #333;
+    font-size: 2em;
 }
 
-.header-actions a {
-    text-decoration: none;
-}
 
 /* Logs Page – Table style */
 .logs-list {

--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@ const tagIcon = document.getElementById('tagIcon');
 const rateIcon = document.getElementById('rateIcon');
 const logsIcon = document.getElementById('logsIcon');
 
-const repoCountBadge = document.getElementById('repoCountBadge');
+const starCountBadge = document.getElementById('starCount');
 const logsCountBadge = document.getElementById('logsCountBadge');
 const logBadge = document.getElementById('logCount');
 
@@ -44,7 +44,7 @@ fetch('data.json')
   .then(data => {
     repos = data;
 
-    if (repoCountBadge) repoCountBadge.textContent = repos.length;
+    if (starCountBadge) starCountBadge.textContent = repos.length;
 
     updateLogCount();
 

--- a/templates/card-styles/README.md
+++ b/templates/card-styles/README.md
@@ -1,0 +1,3 @@
+# Card Style Presets
+
+This folder contains various HTML snippets demonstrating different card designs. Use these files as starting points when styling your own repository cards.


### PR DESCRIPTION
## Summary
- update star counter properly in JS
- restructure header to remove duplicate icons
- enlarge header icons and adjust styles
- apply capsule layout with drop shadow to header
- document card style presets

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685dcb540ab88320b3a1b8a95298634c