### PR TITLE
UI tweaks and card style presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ npx serve
 python3 -m http.server
 ```
 
+### Card style presets
+
+The interface includes a **Card Style** dropdown in the filter bar. Choose a
+preset to apply different looks to the repository cards. More examples can be
+found under `templates/card-styles`.
+
 ### Launch the optional Streamlit dashboard
 
 Install the Python requirements first:

--- a/index.html
+++ b/index.html
@@ -52,6 +52,11 @@
       <option value="language">Language</option>
       <option value="tag">Tag</option>
     </select>
+    <select id="cardStyle">
+      <option value="default">Default Cards</option>
+      <option value="retro">Retro</option>
+      <option value="futuristic">Futuristic</option>
+    </select>
   </div>
 
   <script type="module" src="main.js"></script>

--- a/main.css
+++ b/main.css
@@ -6,21 +6,22 @@ body {
     line-height: 1.6;
     margin: 0;
     padding: 0;
-    padding-top: 60px; /* space for header */
+    padding-top: 100px; /* space for header */
 }
 
 /* Header */
 .main-header {
     position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
+    top: 12px;
+    left: 12px;
+    right: 12px;
     display: flex;
     justify-content: space-between;
     align-items: center;
     padding: 10px 20px;
     background: rgba(255, 255, 255, 0.6);
     backdrop-filter: blur(10px);
+    border-radius: 12px;
     box-shadow: 0 2px 10px rgba(0,0,0,0.1);
     z-index: 1000;
 }
@@ -51,8 +52,8 @@ body {
 }
 
 .icon-btn {
-    width: 32px;
-    height: 32px;
+    width: 64px;
+    height: 64px;
     border-radius: 50%;
     background: rgba(255, 255, 255, 0.8);
     border: none;
@@ -61,6 +62,9 @@ body {
     justify-content: center;
     cursor: pointer;
     transition: background 0.2s, transform 0.2s;
+}
+.icon-btn i {
+    font-size: 32px;
 }
 
 .icon-btn:hover {
@@ -71,8 +75,12 @@ body {
 .badge {
     background: #ff4757;
     color: #fff;
-    border-radius: 12px;
-    padding: 2px 6px;
+    min-width: 20px;
+    height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
     font-size: 0.75em;
 }
 
@@ -88,8 +96,8 @@ body {
 
 .logs-container .badge {
     position: absolute;
-    top: -6px;
-    right: -10px;
+    top: -8px;
+    right: -8px;
 
 }
 
@@ -267,4 +275,30 @@ select:focus {
 /* Logs Page Header */
 .logs-header {
     padding: 20px;
+}
+
+/* Card style presets */
+body.retro .repo-card {
+    background-color: #ffffff;
+    border: 2px solid #cccccc;
+    border-radius: 12px;
+    position: relative;
+}
+body.retro .repo-card::before {
+    content: "";
+    position: absolute;
+    top: -5px;
+    left: -5px;
+    right: -5px;
+    bottom: -5px;
+    border: 2px solid #ffcc00;
+    border-radius: 14px;
+    pointer-events: none;
+}
+
+body.futuristic .repo-card {
+    background: rgba(0,0,0,0.7);
+    color: #fff;
+    border: 1px solid #0ff;
+    box-shadow: 0 0 10px rgba(0,255,255,0.5);
 }

--- a/main.js
+++ b/main.js
@@ -9,6 +9,8 @@ const summarizeIcon = document.getElementById('summarizeIcon');
 const tagIcon = document.getElementById('tagIcon');
 const rateIcon = document.getElementById('rateIcon');
 const logsIcon = document.getElementById('logsIcon');
+const starCountElem = document.getElementById('starCount');
+const cardStyleSelect = document.getElementById('cardStyle');
 
 const repoCountBadge = document.getElementById('repoCountBadge');
 const logsCountBadge = document.getElementById('logsCountBadge');
@@ -45,6 +47,7 @@ fetch('data.json')
     repos = data;
 
     if (repoCountBadge) repoCountBadge.textContent = repos.length;
+    if (starCountElem) starCountElem.textContent = repos.length;
 
     updateLogCount();
 
@@ -186,3 +189,12 @@ rateIcon?.addEventListener('click', () => {
 logsIcon?.addEventListener('click', () => {
   logAction('open-logs', 'page');
 });
+
+cardStyleSelect?.addEventListener('change', () => {
+  document.body.classList.remove('retro', 'futuristic');
+  const style = cardStyleSelect.value;
+  if (style !== 'default') {
+    document.body.classList.add(style);
+  }
+});
+cardStyleSelect?.dispatchEvent(new Event('change'));


### PR DESCRIPTION
## Summary
- capsule header with margin and bigger icons
- fix star counter update
- improved notification badge
- add selectable card style presets
- document card style dropdown in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685dcb540ab88320b3a1b8a95298634c