### PR TITLE
Render GitHub star cards with template-friendly markup

### DIFF
--- a/src/frontend/css/main.css
+++ b/src/frontend/css/main.css
@@ -377,31 +377,104 @@ body.debug-mode::before {
     text-decoration: none;
     word-break: break-word;
 }
-.repo-card p {
-    font-size: 0.9em;
-    color: #555;
-    margin: 4px 0;
+.repo-card .description {
+    font-size: 0.95em;
+    color: #475569;
+    margin: 8px 0 16px;
+    line-height: 1.5;
+    min-height: 48px;
+}
+.repo-card .details {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 12px;
+}
+.repo-card .detail-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    border-radius: 999px;
+    background: #f1f5f9;
+    color: #1f2937;
+    font-size: 0.75em;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+.repo-card .detail-item i {
+    color: #2563eb;
 }
 .metrics {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
+    gap: 10px;
     margin-top: auto;
-    margin-bottom: 10px;
+    margin-bottom: 14px;
 }
 .metric {
-    background: #eee;
-    padding: 5px 8px;
-    border-radius: 4px;
-    font-size: 0.85em;
-    color: #666;
-}
-.languages,
-.topics {
+    background: linear-gradient(135deg, #e2e8f0, #f8fafc);
+    padding: 6px 10px;
+    border-radius: 8px;
     font-size: 0.8em;
-    color: #666;
-    margin-top: 5px;
-    word-break: break-word;
+    color: #475569;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+.metric i {
+    color: #0f172a;
+}
+.repo-card .languages {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 10px;
+}
+.repo-card .language-item {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 4px 10px;
+    font-size: 0.75em;
+    color: #1e293b;
+}
+.repo-card .language-item--empty {
+    background: #fef3c7;
+    border-color: #facc15;
+    color: #92400e;
+}
+.repo-card .language-percent {
+    color: #64748b;
+    font-weight: 600;
+}
+.repo-card .topics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 12px;
+}
+.repo-card .topic {
+    background: #e0f2fe;
+    color: #0f172a;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 0.75em;
+    font-weight: 600;
+}
+.repo-card .topic--empty {
+    background: #fef9c3;
+    color: #92400e;
+}
+.repo-card .date {
+    margin-top: auto;
+    font-size: 0.75em;
+    color: #64748b;
+    text-align: right;
+}
 }
 
 /* Panel + Side Readme */

--- a/src/frontend/css/themes/futuristic.css
+++ b/src/frontend/css/themes/futuristic.css
@@ -33,29 +33,38 @@ body.futuristic .repo-card .description {
     margin: 20px 0;
     text-align: center;
 }
-body.futuristic .repo-card .details {
-    display: flex;
-    justify-content: space-between;
-    font-size: 0.9em;
-    margin-bottom: 15px;
+body.futuristic .repo-card .detail-item {
+    background: rgba(15, 118, 255, 0.1);
+    border: 1px solid rgba(59, 130, 246, 0.4);
+    color: #e0f2fe;
+}
+body.futuristic .repo-card .detail-item i {
+    color: #67e8f9;
+}
+body.futuristic .repo-card .metric {
+    background: rgba(15, 23, 42, 0.6);
+    color: #d1faff;
 }
 body.futuristic .repo-card .languages {
-    font-size: 0.85em;
-    margin-bottom: 10px;
+    gap: 10px;
+}
+body.futuristic .repo-card .language-item {
+    background: rgba(148, 187, 233, 0.2);
+    border-color: rgba(148, 187, 233, 0.35);
+    color: #e0f2fe;
 }
 body.futuristic .repo-card .topics {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 5px;
+    gap: 8px;
 }
 body.futuristic .repo-card .topic {
     background-color: rgba(255,255,255,0.2);
-    padding: 4px 8px;
+    padding: 4px 10px;
     border-radius: 20px;
     font-size: 0.8em;
+    color: #e0f2fe;
 }
 body.futuristic .repo-card .date {
     font-size: 0.8em;
     text-align: right;
-    color: #cccccc;
+    color: #a5f3fc;
 }

--- a/src/frontend/css/themes/minimalist.css
+++ b/src/frontend/css/themes/minimalist.css
@@ -13,3 +13,25 @@ body.minimalist .repo-card h3 {
 body.minimalist .repo-card p {
   margin: 2px 0;
 }
+body.minimalist .repo-card .detail-item,
+body.minimalist .repo-card .metric,
+body.minimalist .repo-card .language-item,
+body.minimalist .repo-card .topic {
+  background: none;
+  border: none;
+  color: #2d3748;
+  padding: 0;
+  gap: 4px;
+}
+body.minimalist .repo-card .detail-item {
+  text-transform: none;
+  letter-spacing: normal;
+  font-size: 0.75em;
+}
+body.minimalist .repo-card .metric {
+  font-size: 0.75em;
+}
+body.minimalist .repo-card .date {
+  color: #4a5568;
+  text-align: left;
+}

--- a/src/frontend/css/themes/neumorphic.css
+++ b/src/frontend/css/themes/neumorphic.css
@@ -15,3 +15,26 @@ body.neumorphic .repo-card .metric {
     background: #d0d0d0;
     border-radius: 12px;
 }
+body.neumorphic .repo-card .detail-item {
+    background: #dcdcdc;
+    border: none;
+    color: #333;
+    text-transform: none;
+    letter-spacing: normal;
+}
+body.neumorphic .repo-card .detail-item i {
+    color: #6366f1;
+}
+body.neumorphic .repo-card .language-item {
+    background: #e4e4e4;
+    border: none;
+    color: #373737;
+}
+body.neumorphic .repo-card .topic {
+    background: #e8e8e8;
+    color: #4b5563;
+    border-radius: 10px;
+}
+body.neumorphic .repo-card .date {
+    color: #6b7280;
+}

--- a/src/frontend/css/themes/professional.css
+++ b/src/frontend/css/themes/professional.css
@@ -45,3 +45,38 @@ body.professional .repo-card .topic {
     border-radius: 4px;
     margin-right: 3px;
 }
+body.professional .repo-card .detail-item {
+    background: none;
+    border: none;
+    color: #475569;
+    text-transform: none;
+    letter-spacing: normal;
+    font-size: 0.8em;
+}
+body.professional .repo-card .detail-item i {
+    color: #94a3b8;
+}
+body.professional .repo-card .metric {
+    background: #eef2f7;
+    color: #1f2937;
+}
+body.professional .repo-card .languages {
+    margin: 12px 0;
+}
+body.professional .repo-card .language-item {
+    background: #eef2ff;
+    border: 1px solid #c7d2fe;
+    color: #3730a3;
+}
+body.professional .repo-card .topic {
+    background-color: #e2e8f0;
+    color: #475569;
+    margin-right: 6px;
+}
+body.professional .repo-card .topic--empty {
+    background: #f1f5f9;
+    color: #64748b;
+}
+body.professional .repo-card .date {
+    color: #475569;
+}

--- a/src/frontend/css/themes/retro.css
+++ b/src/frontend/css/themes/retro.css
@@ -1,55 +1,71 @@
 body.retro .repo-card {
-    background-color: #ffffff;
-    border: 2px solid #cccccc;
-    border-radius: 12px;
-    padding: 25px;
+    background-color: #fffaf0;
+    border: 2px solid #facc15;
+    border-radius: 18px;
+    padding: 26px;
     position: relative;
-    box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+    box-shadow: 0 10px 30px rgba(122, 88, 28, 0.15);
 }
 body.retro .repo-card::before {
     content: "";
     position: absolute;
-    top: -5px;
-    left: -5px;
-    right: -5px;
-    bottom: -5px;
-    border: 2px solid #ffcc00;
-    border-radius: 14px;
+    top: -6px;
+    left: -6px;
+    right: -6px;
+    bottom: -6px;
+    border: 2px dashed rgba(250, 204, 21, 0.7);
+    border-radius: 22px;
+    pointer-events: none;
 }
 body.retro .repo-card h3 {
     margin-top: 0;
-    font-size: 1.3em;
-    color: #333333;
+    font-size: 1.35em;
+    color: #3a2f17;
     text-align: center;
 }
 body.retro .repo-card .description {
-    color: #666666;
-    margin: 15px 0;
+    color: #5c3b0b;
+    margin: 16px 0;
     text-align: center;
 }
-body.retro .repo-card .details {
-    display: flex;
-    justify-content: space-between;
-    font-size: 0.9em;
-    margin-bottom: 10px;
+body.retro .repo-card .detail-item {
+    background: #fff2b2;
+    color: #5c3b0b;
+    border: 1px solid #facc15;
+}
+body.retro .repo-card .detail-item i {
+    color: #ca8a04;
+}
+body.retro .repo-card .metric {
+    background: #ffe8a3;
+    color: #5b3412;
 }
 body.retro .repo-card .languages {
-    font-size: 0.85em;
-    margin-bottom: 10px;
+    gap: 8px;
+}
+body.retro .repo-card .language-item {
+    background: #fff6c5;
+    border-color: #facc15;
+    color: #5b3412;
+}
+body.retro .repo-card .language-item--empty {
+    background: #fde68a;
+    color: #7c2d12;
 }
 body.retro .repo-card .topics {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 5px;
+    gap: 8px;
 }
 body.retro .repo-card .topic {
-    background-color: #e0e0e0;
-    padding: 3px 8px;
-    border-radius: 5px;
-    font-size: 0.8em;
+    background-color: #ffd166;
+    color: #5b2108;
+    border-radius: 12px;
+}
+body.retro .repo-card .topic--empty {
+    background: #ffedd5;
+    color: #7c2d12;
 }
 body.retro .repo-card .date {
-    font-size: 0.8em;
+    font-size: 0.85em;
     text-align: right;
-    color: #999999;
+    color: #7f5539;
 }

--- a/src/frontend/css/themes/terminal.css
+++ b/src/frontend/css/themes/terminal.css
@@ -14,4 +14,28 @@ body.terminal .repo-card a {
 body.terminal .repo-card .metric {
   background-color: #222;
   color: #00ff00;
+  border: 1px solid rgba(0, 255, 0, 0.4);
+}
+body.terminal .repo-card .detail-item {
+  background: rgba(0, 255, 0, 0.1);
+  border: 1px solid rgba(0, 255, 0, 0.4);
+  color: #00ff9d;
+  text-transform: none;
+  letter-spacing: 0.03em;
+}
+body.terminal .repo-card .detail-item i {
+  color: #00ff00;
+}
+body.terminal .repo-card .language-item {
+  background: #181818;
+  border: 1px solid rgba(0, 255, 0, 0.3);
+  color: #00ff9d;
+}
+body.terminal .repo-card .topic {
+  background: #1f1f1f;
+  border: 1px solid rgba(0, 255, 0, 0.3);
+  color: #00ff00;
+}
+body.terminal .repo-card .date {
+  color: rgba(0, 255, 0, 0.75);
 }

--- a/streamlit_app_README.md
+++ b/streamlit_app_README.md
@@ -51,6 +51,12 @@ streamlit run src/streamlit_app/app.py
 
 The app will be available at http://localhost:8501
 
+## Accessing the Dashboard
+
+- **Hosted deployment:** The production dashboard is available at [https://git-stars.streamlit.app](https://git-stars.streamlit.app). Use the same GitHub account that owns the repository to access private deployments.
+- **From the web UI:** The Vite frontend includes a floating Streamlit logo button in the lower-right corner; click it to launch the Streamlit dashboard in a new tab.
+- **Local preview:** Run `npm run streamlit` to generate the latest data (`npm run setup:streamlit` is run automatically) and open the app locally with Streamlit.
+
 ## Data Files
 
 The app expects the following data files in the `data` directory:


### PR DESCRIPTION
## Summary
- update the Vite frontend to render GitHub stars with template-ready card markup and reusable helpers
- refresh the default card styling and theme-specific overrides to match the new structure
- document the public and local entry points for the companion Streamlit dashboard

## Testing
- npm run test:data

------
https://chatgpt.com/codex/tasks/task_e_68d813a984a08320b45d05631c6c28ce