### PR TITLE
Fix missing theme styles for card interfaces

### DIFF
--- a/src/frontend/css/main.css
+++ b/src/frontend/css/main.css
@@ -1,4 +1,10 @@
 @import url("./index.css");
+@import url("./themes/retro.css");
+@import url("./themes/futuristic.css");
+@import url("./themes/professional.css");
+@import url("./themes/terminal.css");
+@import url("./themes/neumorphic.css");
+@import url("./themes/minimalist.css");
 
 /* General Layout */
 body {


### PR DESCRIPTION
## Summary
- import all theme stylesheets into the main frontend bundle so alternate card interfaces render correctly

## Testing
- npm run test:data

------
https://chatgpt.com/codex/tasks/task_e_68d819eaa4688320a110abee7959ff5d