### PR TITLE
Fix Vite build output path for GitHub Pages deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "description": "I created this list using `stargazed`, a Node.js package that generates this markdown file from my starred repositories, helping me track and organize my discoveries. The automation workflow is handled by GitHub Actions, ensuring the list is always up to date.",
   "scripts": {
-    "dev": "vite src/frontend",
+    "dev": "vite --config vite.config.js",
     "build": "npm run build:frontend && npm run build:data",
-    "build:frontend": "vite build src/frontend --outDir dist",
+    "build:frontend": "vite build --config vite.config.js",
     "build:data": "node scripts/generator.js",
     "build:readme": "node scripts/generator.js",
     "build:readme-local": "node scripts/stargazed.js",

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,33 +2,25 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'path';
 
+const rootDir = resolve(__dirname, 'src/frontend');
+
 export default defineConfig({
-  // Specify the correct base path (especially important if deploying to a subdirectory)
+  root: rootDir,
   base: './',
-
-  // Configure the public directory where static assets should be served from
   publicDir: resolve(__dirname, 'public'),
-
-  // Build options
   build: {
-    outDir: 'dist',
+    outDir: resolve(__dirname, 'dist'),
     assetsDir: 'assets',
-    // Generate sourcemaps for better debugging
     sourcemap: true,
+    emptyOutDir: true,
   },
-
-  // Configure server options
   server: {
-    // Show overlay on errors
     hmr: { overlay: true },
-    // Enable automatic opening in browser
     open: true,
   },
-
-  // Resolve aliases for easier imports
   resolve: {
     alias: {
-      '@': resolve(__dirname, 'src/frontend'),
+      '@': rootDir,
     },
   },
 });


### PR DESCRIPTION
## Summary
- update the Vite dev/build scripts to use the shared configuration
- point Vite at the frontend source directory and emit the build to the repository root for GitHub Pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8207664e08320b099c39daa67b336