### PR TITLE
Fix Streamlit sidebar string formatting

### DIFF
--- a/src/streamlit_app/app.py
+++ b/src/streamlit_app/app.py
@@ -242,8 +242,14 @@ def main():
 
     # Display app information
     st.sidebar.markdown("## Git Stars Dashboard")
-    st.sidebar.markdown("This dashboard visualizes your GitHub starred repositories and generates synthetic educational content based on repository topics.")
-st.sidebar.markdown("**Note:** The learning paths and research spotlights are built directly from your starred repositories' topics, languages, and update history.")
+    st.sidebar.markdown(
+        "This dashboard visualizes your GitHub starred repositories and generates synthetic "
+        "educational content based on repository topics."
+    )
+    st.sidebar.markdown(
+        "**Note:** The learning paths and research spotlights are built directly from your starred "
+        "repositories' topics, languages, and update history."
+    )
 
     with github_tab:
         render_cards(filtered_repos, card_type="repo")


### PR DESCRIPTION
## Summary
- fix the sidebar markdown strings so they are wrapped correctly across multiple lines
- prevent indentation errors when running the Streamlit app

## Testing
- python -m compileall src/streamlit_app/app.py

------
https://chatgpt.com/codex/tasks/task_e_68d825f0001483209ad3ad9d1b9e82ef