### PR TITLE
Add local agent-events module and update project aliases

### DIFF
--- a/src/lib/agent-events.ts
+++ b/src/lib/agent-events.ts
@@ -1,0 +1,41 @@
+export type HouseId = string;
+
+interface EventBase {
+  type: string;
+  timestamp: string;
+  [key: string]: unknown;
+}
+
+export interface CustomEvent<TData = unknown> extends EventBase {
+  type: `${HouseId}:${string}`;
+  house_id: HouseId;
+  data: TData;
+}
+
+export type AgentEvent = EventBase | CustomEvent;
+
+export const createCustomEvent = <TData>(
+  houseId: HouseId,
+  eventType: string,
+  data: TData,
+): CustomEvent<TData> => ({
+  type: `${houseId}:${eventType}`,
+  house_id: houseId,
+  timestamp: new Date().toISOString(),
+  data,
+});
+
+export const getEventHouseId = (event: AgentEvent): string => {
+  if (typeof event.house_id === 'string' && event.house_id.length > 0) {
+    return event.house_id;
+  }
+
+  if (typeof event.type === 'string') {
+    const [prefix] = event.type.split(':');
+    if (prefix && prefix.length > 0) {
+      return prefix;
+    }
+  }
+
+  return 'unknown';
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
     "baseUrl": ".",
     "paths": {
       "@": ["src"],
-      "@agent-events": ["../../htdi-collective-agency/lib/agent-events.ts"]
+      "@agent-events": ["src/lib/agent-events.ts"]
     }
   },
   "include": ["src"],

--- a/vite.config.js
+++ b/vite.config.js
@@ -39,7 +39,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': rootDir,
-      '@agent-events': resolve(__dirname, '../../htdi-collective-agency/lib/agent-events.ts'),
+      '@agent-events': resolve(__dirname, 'src/lib/agent-events.ts'),
     },
   },
 });


### PR DESCRIPTION
### Motivation
- Introduce a local, strongly-typed representation of agent events to remove the external dependency and provide utilities for creating and interpreting events.
- Redirect project path/alias resolution to the new local module so imports resolve within this repository.

### Description
- Add `src/lib/agent-events.ts` which defines `HouseId`, `EventBase`, `CustomEvent`, `AgentEvent`, `createCustomEvent`, and `getEventHouseId` utilities for constructing and extracting house IDs from events.
- Update `tsconfig.json` to map the `@agent-events` path to `src/lib/agent-events.ts` instead of the external package path.
- Update `vite.config.js` to alias `@agent-events` to the local `src/lib/agent-events.ts` so bundling and dev-server resolution use the local file.

### Testing
- Run TypeScript type-check with `tsc --noEmit`, which completed successfully against the updated types.
- Run a local build with `vite build`, which completed successfully and resolved the new alias to the local module.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e09f44e21083208bea3b585eaf14a8)