### PR TITLE
Fix ESLint failures in git-stars UI and stream client

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -221,7 +221,7 @@ function App() {
 
   // Filter and Sort Logic
   const processedRepos = useMemo(() => {
-    let filtered = allRepos.filter((repo) => {
+    const filtered = allRepos.filter((repo) => {
       const matchSearch =
         !searchTerm ||
         repo.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -241,8 +241,7 @@ function App() {
         case 'name':
           return a.name.localeCompare(b.name);
         case 'date':
-          // Assuming 'date' field exists on repo object in data.json equivalent to legacy 'date'
-          return new Date((b as any).date || 0).getTime() - new Date((a as any).date || 0).getTime();
+          return new Date(b.date || 0).getTime() - new Date(a.date || 0).getTime();
         case 'created':
            // Legacy mapped 'created' to 'last_updated'
           return new Date(b.last_updated).getTime() - new Date(a.last_updated).getTime();

--- a/src/components/ActivityLog.tsx
+++ b/src/components/ActivityLog.tsx
@@ -6,6 +6,12 @@ import { Download, Activity, Server, Database } from 'lucide-react';
 const EVENT_BUS_URL = import.meta.env.VITE_EVENT_BUS_URL || '/bus';
 const EVENT_BUS_SSE_URL = `${EVENT_BUS_URL}/events?agency=git-stars`;
 
+type EventDetails = {
+  data?: unknown;
+  tool_name?: string;
+  response_id?: string;
+};
+
  export const ActivityLog: React.FC = () => {
   const [events, setEvents] = useState<AgentEvent[]>([]);
   const [filterType, setFilterType] = useState<string>('all');
@@ -66,6 +72,14 @@ const EVENT_BUS_SSE_URL = `${EVENT_BUS_URL}/events?agency=git-stars`;
       if (type.startsWith('tool')) return <Database size={16} className="text-orange-500"/>
       return <Activity size={16} className="text-gray-400"/>
   }
+
+  const getEventDetails = (event: AgentEvent) => {
+    const details = event as AgentEvent & EventDetails;
+    if (details.data !== undefined) return JSON.stringify(details.data);
+    if (details.tool_name) return `Call: ${details.tool_name}`;
+    if (details.response_id) return `Resp: ${details.response_id}`;
+    return JSON.stringify(event);
+  };
 
   return (
     <div className="activity-container">
@@ -137,10 +151,7 @@ const EVENT_BUS_SSE_URL = `${EVENT_BUS_URL}/events?agency=git-stars`;
                                 </span>
                             </td>
                             <td className="text-muted" style={{ maxWidth: '400px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                {'data' in event ? JSON.stringify((event as any).data) 
-                                 : 'tool_name' in event ? `Call: ${(event as any).tool_name}`
-                                 : 'response_id' in event ? `Resp: ${(event as any).response_id}` 
-                                 : JSON.stringify(event)}
+                                {getEventDetails(event)}
                             </td>
                         </tr>
                     ))

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { X, Send, Bot, User as UserIcon, Loader, Wrench } from 'lucide-react';
 import { Repo } from '../types';
 import {
@@ -85,26 +85,13 @@ export function ChatPanel({
     }
   }, [messages, toolCalls]);
 
-  useEffect(() => {
-    if (!isOpen) return;
-    if (!prefill) return;
-    if (lastPrefillRef.current === prefill) return;
-
-    lastPrefillRef.current = prefill;
-    setInput(prefill);
-    if (autoSend) {
-      handleSend(prefill);
-      onPrefillConsumed?.();
-    }
-  }, [isOpen, prefill, autoSend, onPrefillConsumed]);
-
   const handleClose = () => {
     streamRef.current?.abort();
     streamRef.current = null;
     onClose();
   };
 
-  const handleSend = async (override?: string) => {
+  const handleSend = useCallback(async (override?: string) => {
     if (!repo) return;
     const content = (override ?? input).trim();
     if (!content) return;
@@ -163,7 +150,20 @@ export function ChatPanel({
         ]);
       },
     });
-  };
+  }, [repo, input, messages, defaultModel, agentId, tools]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (!prefill) return;
+    if (lastPrefillRef.current === prefill) return;
+
+    lastPrefillRef.current = prefill;
+    setInput(prefill);
+    if (autoSend) {
+      handleSend(prefill);
+      onPrefillConsumed?.();
+    }
+  }, [isOpen, prefill, autoSend, onPrefillConsumed, handleSend]);
 
   const handleStreamEvent = (event: OpenResponsesEvent, assistantId: string) => {
     if (event.type === 'response.output_text.delta' && event.delta) {

--- a/src/components/ReadmePanel.tsx
+++ b/src/components/ReadmePanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import { ExternalLink, X, Sparkles, Wand2 } from 'lucide-react';
@@ -21,6 +21,8 @@ interface ChatMessage {
   role: 'user' | 'assistant';
   content: string;
 }
+
+type ModelDescriptor = string | { id?: string; model?: string };
 
 export function ReadmePanel({ isOpen, onClose, repo, actionPrompt, autoRunAction, onActionConsumed, actionPresets }: ReadmePanelProps) {
   const [content, setContent] = useState<string>('');
@@ -51,7 +53,7 @@ export function ReadmePanel({ isOpen, onClose, repo, actionPrompt, autoRunAction
     try {
       const html = await marked.parse(text);
       setContent(DOMPurify.sanitize(html));
-    } catch (error) {
+    } catch {
       const escaped = text
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
@@ -60,22 +62,17 @@ export function ReadmePanel({ isOpen, onClose, repo, actionPrompt, autoRunAction
     }
   };
 
-  const getReadmeExcerpt = () => {
-    if (!rawMarkdown) return '';
-    return rawMarkdown.slice(0, 4000);
-  };
-
-  const buildConversation = (prompt: string) => {
-    const excerpt = getReadmeExcerpt();
+  const buildConversation = useCallback((prompt: string) => {
+    const excerpt = rawMarkdown ? rawMarkdown.slice(0, 4000) : '';
     const systemPrompt = `${buildSystemPrompt(repo)}\n\nREADME excerpt:\n${excerpt || 'No README loaded.'}`;
     return [
       { role: 'system', content: systemPrompt },
       ...messages.map((m) => ({ role: m.role, content: m.content })),
       { role: 'user', content: prompt },
     ];
-  };
+  }, [repo, rawMarkdown, messages]);
 
-  const runAction = (prompt: string, title?: string) => {
+  const runAction = useCallback((prompt: string, title?: string) => {
     if (!repo) return;
     const actionTitle = title || 'Action';
     const actionId = `action-${Date.now()}`;
@@ -118,7 +115,7 @@ export function ReadmePanel({ isOpen, onClose, repo, actionPrompt, autoRunAction
         setOverlayContent(`Error: ${error.message}`);
       },
     });
-  };
+  }, [repo, selectedModel, buildConversation]);
 
   useEffect(() => {
     if (isOpen && repo) {
@@ -162,8 +159,8 @@ export function ReadmePanel({ isOpen, onClose, repo, actionPrompt, autoRunAction
             : Array.isArray(data?.data)
               ? data.data
               : [];
-        const normalized = list
-          .map((m: any) => (typeof m === 'string' ? m : m?.id || m?.model))
+        const normalized = (list as ModelDescriptor[])
+          .map((m) => (typeof m === 'string' ? m : m?.id || m?.model))
           .filter(Boolean);
         if (normalized.length > 0) {
           setModels(normalized);
@@ -192,7 +189,7 @@ export function ReadmePanel({ isOpen, onClose, repo, actionPrompt, autoRunAction
     lastActionRef.current = actionPrompt;
     runAction(actionPrompt, 'Quick action');
     onActionConsumed?.();
-  }, [isOpen, repo, actionPrompt, autoRunAction, onActionConsumed]);
+  }, [isOpen, repo, actionPrompt, autoRunAction, onActionConsumed, runAction]);
 
   return (
     <div className={`readme-panel ${isOpen ? 'open' : ''}`}>

--- a/src/components/TopicTimeline.tsx
+++ b/src/components/TopicTimeline.tsx
@@ -15,6 +15,13 @@ interface TopicTimelineProps {
   repos: Repo[];
 }
 
+interface TimelineEntry {
+  name: string;
+  dateObj: Date;
+  display: string;
+  [topic: string]: string | number | Date;
+}
+
 const COLORS = [
   '#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#a855f7', 
   '#ec4899', '#f43f5e', '#64748b', '#0ea5e9', '#84cc16'
@@ -54,7 +61,7 @@ export const TopicTimeline: React.FC<TopicTimelineProps> = ({ repos }) => {
     const maxDate = new Date(); // Today
 
     // 3. Create Continuous Week Buckets
-    const buckets: Record<string, any> = {};
+    const buckets: Record<string, TimelineEntry> = {};
     const current = new Date(minDate);
     
     while (current <= maxDate) {
@@ -63,7 +70,7 @@ export const TopicTimeline: React.FC<TopicTimelineProps> = ({ repos }) => {
       const week = getWeekNumber(current);
       const key = `${year}-W${week.toString().padStart(2, '0')}`;
       
-      const entry: any = { 
+      const entry: TimelineEntry = {
         name: key,
         dateObj: new Date(current), // for sorting/display
         display: current.toLocaleDateString(), // simplified

--- a/src/lib/openresponses-client.ts
+++ b/src/lib/openresponses-client.ts
@@ -51,9 +51,13 @@ async function parseSSEStream(
   const decoder = new TextDecoder();
   let buffer = '';
 
-  while (true) {
+  let streamDone = false;
+  while (!streamDone) {
     const { done, value } = await reader.read();
-    if (done) break;
+    streamDone = done;
+    if (streamDone) {
+      break;
+    }
 
     buffer += decoder.decode(value, { stream: true });
     const lines = buffer.split('\n');
@@ -67,7 +71,7 @@ async function parseSSEStream(
       try {
         const event = JSON.parse(data) as OpenResponsesEvent;
         onEvent(event);
-      } catch (error) {
+      } catch {
         console.warn('[OpenResponses] Failed to parse event:', data);
       }
     }


### PR DESCRIPTION
### Motivation
- Lint was failing (`pnpm run lint`) due to a mix of pre-existing issues across UI components and the SSE parser, preventing CI/quality checks from passing.
- Changes aim to resolve ESLint errors/warnings without changing runtime behavior.

### Description
- Updated `src/App.tsx` to use `const filtered` and replace `any`-based date access with the typed `Repo.date` field for sorting to satisfy `prefer-const` and avoid `any` usage in sorting.
- Refactored SSE parsing in `src/lib/openresponses-client.ts` to remove a constant-condition loop and an unused catch variable by using a `streamDone` flag and simplifying the `catch` block.
- Replaced `any` casts in `src/components/ActivityLog.tsx` with a typed `EventDetails` helper and a `getEventDetails` function to produce stable, typed event detail rendering.
- Stabilized hook dependencies and avoided missing-deps lint warnings in `src/components/ChatPanel.tsx` by memoizing `handleSend` with `useCallback` and updating the prefill `useEffect` to include `handleSend`.
- Improved `src/components/ReadmePanel.tsx` by adding a `ModelDescriptor` type, memoizing `buildConversation` and `runAction` with `useCallback`, removing an unused helper, and fixing `useEffect` dependency arrays.
- Added explicit `TimelineEntry` typing in `src/components/TopicTimeline.tsx` to replace `any`-typed buckets and ensure clearer typing for chart data.

### Testing
- Ran `pnpm run lint` and it completed successfully with `--max-warnings 0` (lint now passes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0a25049788320862812bc8e1aefb0)