### PR TITLE
Gate Vercel deploy when secrets missing and fix TypeScript build errors

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   vercel-deploy:
     runs-on: ubuntu-latest
+    env:
+      HAS_VERCEL_SECRETS: ${{ secrets.VERCEL_TOKEN != '' && secrets.VERCEL_ORG_ID != '' && secrets.VERCEL_PROJECT_ID != '' }}
 
     steps:
       - name: Checkout repository
@@ -37,9 +39,11 @@ jobs:
         run: pnpm run build
 
       - name: Install Vercel CLI
+        if: env.HAS_VERCEL_SECRETS == 'true'
         run: npm install -g vercel@latest
 
       - name: Pull Vercel Environment Information
+        if: env.HAS_VERCEL_SECRETS == 'true'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -48,6 +52,7 @@ jobs:
         continue-on-error: true
 
       - name: Build Project Artifacts
+        if: env.HAS_VERCEL_SECRETS == 'true'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -55,6 +60,7 @@ jobs:
         run: vercel build --prod
 
       - name: Deploy Project Artifacts to Vercel
+        if: env.HAS_VERCEL_SECRETS == 'true'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -63,6 +69,13 @@ jobs:
         id: deploy
 
       - name: Output deployment URL
+        if: env.HAS_VERCEL_SECRETS == 'true'
         run: |
           echo "Deployment complete!"
           echo "Visit your site at the Vercel URL provided above"
+
+      - name: Skip Vercel deploy (missing secrets)
+        if: env.HAS_VERCEL_SECRETS != 'true'
+        run: |
+          echo "Skipping Vercel deployment because one or more required GitHub secrets are missing:"
+          echo "VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID"

--- a/src/components/ReadmePanel.tsx
+++ b/src/components/ReadmePanel.tsx
@@ -161,10 +161,10 @@ export function ReadmePanel({ isOpen, onClose, repo, actionPrompt, autoRunAction
               : [];
         const normalized = (list as ModelDescriptor[])
           .map((m) => (typeof m === 'string' ? m : m?.id || m?.model))
-          .filter(Boolean);
+          .filter((model): model is string => Boolean(model));
         if (normalized.length > 0) {
           setModels(normalized);
-          setSelectedModel((prev) => (normalized.includes(prev) ? prev : normalized[0]));
+          setSelectedModel((prev) => (normalized.includes(prev) ? prev : normalized[0] ?? prev));
         }
       })
       .catch(() => null);

--- a/src/components/TopicTimeline.tsx
+++ b/src/components/TopicTimeline.tsx
@@ -98,7 +98,8 @@ export const TopicTimeline: React.FC<TopicTimelineProps> = ({ repos }) => {
       if (buckets[key]) {
         repo.topics.forEach(topic => {
           if (topTopics.includes(topic)) {
-            buckets[key][topic]++;
+            const currentCount = buckets[key][topic];
+            buckets[key][topic] = typeof currentCount === 'number' ? currentCount + 1 : 1;
           }
         });
       }


### PR DESCRIPTION
### Motivation
- Vercel deployment jobs were hard-failing in CI when required secrets were not present, causing noisy failures for non-deploy environments.
- The local production build was failing due to TypeScript errors in model normalization and topic-count arithmetic, blocking `pnpm run build`.

### Description
- Add an `HAS_VERCEL_SECRETS` environment check and guard the Vercel CLI/pull/build/deploy steps with `if: env.HAS_VERCEL_SECRETS == 'true'` in `.github/workflows/vercel-deploy.yml`, and add a clear skip step when secrets are missing.
- Narrow model normalization in `src/components/ReadmePanel.tsx` by using `.filter((model): model is string => Boolean(model))` and make `setSelectedModel` fallback safer (`normalized[0] ?? prev`).
- Fix topic counting in `src/components/TopicTimeline.tsx` by checking `typeof currentCount === 'number'` before incrementing the bucket value to avoid arithmetic on union-typed values.

### Testing
- Ran `pnpm run build` after the fixes and the build completed successfully (TypeScript typecheck and `vite build` passed).
- Prior to these changes `pnpm run build` failed with TypeScript errors which are resolved by the patch.
- Tried to inspect Vercel deployment logs with `npx vercel inspect ... --logs` but the CLI attempt failed due to network/auth (`ENETUNREACH`), so remote deploy logs could not be validated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0a84f1d6483208d3682ad0739d697)