### PR TITLE
Fix repo list not rendering when data.json is flat

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,18 @@ import { MyReposPanel } from './components/MyReposPanel';
 import { logger } from './lib/logger';
 import { Search, Github, LayoutGrid, Table as TableIcon, BarChart3, Star, Activity, Compass, User } from 'lucide-react';
 
+function normalizeRepoPayload(jsonData: unknown): Repo[] {
+  if (!Array.isArray(jsonData)) return [];
+
+  // Newer generators emit a flat repo array.
+  if (jsonData.length === 0 || (jsonData[0] && typeof jsonData[0] === 'object' && 'name' in jsonData[0])) {
+    return jsonData as Repo[];
+  }
+
+  // Legacy format grouped repos by language.
+  return (jsonData as LanguageGroup[]).flatMap((g) => g.repos || []);
+}
+
 function App() {
   const [allRepos, setAllRepos] = useState<Repo[]>([]);
   const [loading, setLoading] = useState(true);
@@ -138,8 +150,7 @@ function App() {
         return response.json();
       })
       .then((jsonData) => {
-
-        const flat = jsonData.flatMap((g: LanguageGroup) => g.repos || []);
+        const flat = normalizeRepoPayload(jsonData);
         setAllRepos(flat);
         setLoading(false);
       })


### PR DESCRIPTION
### Motivation
- The UI assumed `public/data.json` used the legacy grouped shape (`LanguageGroup[]`) and ran `flatMap(g => g.repos)`, which produced an empty `allRepos` when the deployed payload is a flat array of repos.
- This caused favorites, starred counts, and stats to display `0` despite successful deployments.

### Description
- Add `normalizeRepoPayload(jsonData: unknown): Repo[]` to `src/App.tsx` to support both payload shapes: a flat `Repo[]` and the legacy `LanguageGroup[]` grouped format.
- Replace the previous `jsonData.flatMap(...)` usage with `normalizeRepoPayload(jsonData)` when loading `/data.json` so `allRepos` is populated correctly regardless of format.
- Changes are limited to `src/App.tsx` and do not alter other app logic or types.

### Testing
- Ran a production build with `npm run build`, which completed successfully without errors.
- Verified the app can parse a flat `public/data.json` payload and set `allRepos` (manual verification during rollout); no automated unit tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e180c14ec483208d4187bddf837ee8)