### PR TITLE
Support legacy/grouped repo payloads and add about-URL overrides for repo links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,18 @@ import { MyReposPanel } from './components/MyReposPanel';
 import { logger } from './lib/logger';
 import { Search, Github, LayoutGrid, Table as TableIcon, BarChart3, Star, Activity, Compass, User } from 'lucide-react';
 
+function normalizeRepoPayload(jsonData: unknown): Repo[] {
+  if (!Array.isArray(jsonData)) return [];
+
+  // Newer generators emit a flat repo array.
+  if (jsonData.length === 0 || (jsonData[0] && typeof jsonData[0] === 'object' && 'name' in jsonData[0])) {
+    return jsonData as Repo[];
+  }
+
+  // Legacy format grouped repos by language.
+  return (jsonData as LanguageGroup[]).flatMap((g) => g.repos || []);
+}
+
 function App() {
   const [allRepos, setAllRepos] = useState<Repo[]>([]);
   const [loading, setLoading] = useState(true);
@@ -138,8 +150,7 @@ function App() {
         return response.json();
       })
       .then((jsonData) => {
-
-        const flat = jsonData.flatMap((g: LanguageGroup) => g.repos || []);
+        const flat = normalizeRepoPayload(jsonData);
         setAllRepos(flat);
         setLoading(false);
       })

--- a/src/components/ReadmePanel.tsx
+++ b/src/components/ReadmePanel.tsx
@@ -5,6 +5,7 @@ import { ExternalLink, X, Sparkles, Wand2 } from 'lucide-react';
 import { Repo } from '../types';
 import { streamOpenResponses } from '../lib/openresponses-client';
 import { buildGitStarsTools, buildSystemPrompt, EVENT_BUS_URL } from '../lib/orchestrator';
+import { getRepoAboutUrl } from '../lib/repo-links';
 
 interface ReadmePanelProps {
   isOpen: boolean;
@@ -48,6 +49,7 @@ export function ReadmePanel({ isOpen, onClose, repo, actionPrompt, autoRunAction
   ];
 
   const actions = actionPresets && actionPresets.length > 0 ? actionPresets : defaultActions;
+  const aboutUrl = repo ? getRepoAboutUrl(repo) : '#';
 
   const renderMarkdown = async (text: string) => {
     try {
@@ -199,7 +201,7 @@ export function ReadmePanel({ isOpen, onClose, repo, actionPrompt, autoRunAction
                <X size={20} />
             </button>
             {repo && (
-               <a href={repo.url} target="_blank" rel="noopener noreferrer" className="readme-repo-link">
+               <a href={aboutUrl} target="_blank" rel="noopener noreferrer" className="readme-repo-link">
                   Visit Repo <ExternalLink size={16} />
                </a>
             )}

--- a/src/components/RepoCard.tsx
+++ b/src/components/RepoCard.tsx
@@ -1,6 +1,7 @@
 import type { MouseEvent } from 'react';
 import { Repo } from '../types';
 import { Star, GitFork, Calendar, MessageSquare, Microscope, Copy, Bookmark, Lock } from 'lucide-react';
+import { getRepoAboutUrl } from '../lib/repo-links';
 
 interface RepoCardProps {
   repo: Repo;
@@ -14,6 +15,8 @@ interface RepoCardProps {
 }
 
 export function RepoCard({ repo, onClick, onChat, onResearch, onSimilar, onContextMenu, onBookmark, isBookmarked }: RepoCardProps) {
+  const aboutUrl = getRepoAboutUrl(repo);
+
   return (
     <div
       className="repo-card"
@@ -31,7 +34,7 @@ export function RepoCard({ repo, onClick, onChat, onResearch, onSimilar, onConte
         <Bookmark size={16} fill={isBookmarked ? 'currentColor' : 'none'} />
       </button>
       <h3 className="repo-title">
-        <a href={repo.url} target="_blank" rel="noopener noreferrer" onClick={(e) => e.stopPropagation()}>
+        <a href={aboutUrl} target="_blank" rel="noopener noreferrer" onClick={(e) => e.stopPropagation()}>
           {repo.private ? (
             <span className="repo-title__lock" title="Private repository">
               <Lock size={14} />

--- a/src/lib/repo-links.ts
+++ b/src/lib/repo-links.ts
@@ -1,0 +1,10 @@
+import { Repo } from '../types';
+
+const ABOUT_OVERRIDES: Record<string, string> = {
+  'KBLLR/git-stars': 'https://gitstars-gb6ccye00-kbllr-projects.vercel.app/',
+};
+
+export function getRepoAboutUrl(repo: Repo): string {
+  const key = `${repo.author}/${repo.name}`;
+  return ABOUT_OVERRIDES[key] || repo.url;
+}


### PR DESCRIPTION
### Motivation
- Accept both legacy language-grouped and newer flat repo arrays from `/data.json` to avoid data loss when loading repositories.
- Centralize repo "about" link resolution to allow overrides for special cases where the displayed link should differ from `repo.url`.
- Ensure the Readme panel and Repo card open the intended about page for a repository.

### Description
- Add `normalizeRepoPayload` in `src/App.tsx` to detect and flatten legacy `LanguageGroup[]` payloads or return a flat `Repo[]`, and use it when fetching `/data.json`.
- Add `src/lib/repo-links.ts` exporting `getRepoAboutUrl` with an `ABOUT_OVERRIDES` map for special-cased repo about URLs.
- Replace direct uses of `repo.url` with `getRepoAboutUrl(repo)` in `src/components/ReadmePanel.tsx` and `src/components/RepoCard.tsx` and add the necessary imports.

### Testing
- Ran the production build with `npm run build` which completed successfully.
- Executed the test suite with `npm test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e180c14ec483208d4187bddf837ee8)