### PR TITLE
ci: sync my public/private repositories in deploy workflow

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HAS_VERCEL_SECRETS: ${{ secrets.VERCEL_TOKEN != '' && secrets.VERCEL_ORG_ID != '' && secrets.VERCEL_PROJECT_ID != '' }}
+      HAS_MY_REPOS_TOKEN: ${{ secrets.MY_REPOS_GITHUB_TOKEN != '' }}
 
     steps:
       - name: Checkout repository
@@ -32,6 +33,18 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Sync my repositories (public + private)
+        if: env.HAS_MY_REPOS_TOKEN == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.MY_REPOS_GITHUB_TOKEN }}
+        run: pnpm run sync:mine
+
+      - name: Skip my repos sync (missing secret)
+        if: env.HAS_MY_REPOS_TOKEN != 'true'
+        run: |
+          echo "Skipping my-repos sync because MY_REPOS_GITHUB_TOKEN is not configured."
+          echo "Add a classic PAT or fine-grained token with access to your repositories."
 
       - name: Build project
         env:


### PR DESCRIPTION
### Motivation
- Ensure the deployed site has an up-to-date snapshot of the signed-in user’s repositories (public + private) by refreshing `public/my-repos.json` during deploy. 
- Make repo sync optional and safe so deployments still run when a personal token is not provided.

### Description
- Added `HAS_MY_REPOS_TOKEN` environment flag and a conditional step to run `pnpm run sync:mine` when `MY_REPOS_GITHUB_TOKEN` is configured in the workflow in `.github/workflows/vercel-deploy.yml`. 
- Added a clear fallback step that logs instructions when `MY_REPOS_GITHUB_TOKEN` is missing so the workflow remains non-blocking. 
- Kept existing build and Vercel deploy steps unchanged so normal deploy behavior is preserved.

### Testing
- Ran `pnpm run lint` which completed successfully. 
- Ran `pnpm run build` which completed successfully and produced the production build artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e18a648be8832084adfbb57485085c)