### PR TITLE
Add runtime settings panel and route chat/readme flows to selectable runtime target

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { Statistics } from './components/Statistics';
 import { ActivityLog } from './components/ActivityLog';
 import { HighlightsPanel } from './components/HighlightsPanel';
 import { MyReposPanel } from './components/MyReposPanel';
+import { RuntimeSettingsPanel } from './components/RuntimeSettingsPanel';
 import { logger } from './lib/logger';
 import { Search, Github, LayoutGrid, Table as TableIcon, BarChart3, Star, Activity, Compass, User } from 'lucide-react';
 
@@ -376,6 +377,7 @@ function App() {
                <Star size={14} fill="currentColor" className="text-muted" /> 
                {view === 'mine' ? processedMineRepos.length : processedRepos.length} Repos
             </div>
+            <RuntimeSettingsPanel />
         </div>
       </header>
 

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -9,6 +9,7 @@ import {
   HOUSE_ID,
 } from '../lib/orchestrator';
 import { OpenResponsesEvent, streamOpenResponses } from '../lib/openresponses-client';
+import { loadRuntimeSettings, resolveRuntimeTarget, SETTINGS_EVENT } from '../lib/settings';
 
 interface ChatPanelProps {
   isOpen: boolean;
@@ -48,6 +49,9 @@ export function ChatPanel({
   const [isLoading, setIsLoading] = useState(false);
   const [toolCalls, setToolCalls] = useState<Record<string, ToolCall>>({});
   const [defaultModel, setDefaultModel] = useState<string | null>(null);
+  const [runtimeTarget, setRuntimeTarget] = useState(() =>
+    resolveRuntimeTarget(loadRuntimeSettings())
+  );
   const scrollRef = useRef<HTMLDivElement>(null);
   const streamRef = useRef<AbortController | null>(null);
   const lastPrefillRef = useRef<string | null>(null);
@@ -63,6 +67,18 @@ export function ChatPanel({
         }
       })
       .catch(() => null);
+  }, []);
+
+  useEffect(() => {
+    const applySettings = () => {
+      setRuntimeTarget(resolveRuntimeTarget(loadRuntimeSettings()));
+    };
+    window.addEventListener(SETTINGS_EVENT, applySettings);
+    window.addEventListener('storage', applySettings);
+    return () => {
+      window.removeEventListener(SETTINGS_EVENT, applySettings);
+      window.removeEventListener('storage', applySettings);
+    };
   }, []);
 
   useEffect(() => {
@@ -122,9 +138,9 @@ export function ChatPanel({
     streamRef.current?.abort();
 
     streamRef.current = streamOpenResponses({
-      endpoint: `${EVENT_BUS_URL}/chat`,
+      endpoint: `${runtimeTarget.busUrl}/chat`,
       body: {
-        model: defaultModel || 'local-model',
+        model: runtimeTarget.model || defaultModel || 'local-model',
         messages: conversation,
         agent_id: agentId,
         house_id: HOUSE_ID,
@@ -150,7 +166,7 @@ export function ChatPanel({
         ]);
       },
     });
-  }, [repo, input, messages, defaultModel, agentId, tools]);
+  }, [repo, input, messages, defaultModel, agentId, tools, runtimeTarget]);
 
   useEffect(() => {
     if (!isOpen) return;

--- a/src/components/ReadmePanel.tsx
+++ b/src/components/ReadmePanel.tsx
@@ -4,8 +4,9 @@ import DOMPurify from 'dompurify';
 import { ExternalLink, X, Sparkles, Wand2 } from 'lucide-react';
 import { Repo } from '../types';
 import { streamOpenResponses } from '../lib/openresponses-client';
-import { buildGitStarsTools, buildSystemPrompt, EVENT_BUS_URL } from '../lib/orchestrator';
+import { buildGitStarsTools, buildSystemPrompt } from '../lib/orchestrator';
 import { getRepoAboutUrl } from '../lib/repo-links';
+import { loadRuntimeSettings, resolveRuntimeTarget, SETTINGS_EVENT } from '../lib/settings';
 
 interface ReadmePanelProps {
   isOpen: boolean;
@@ -33,6 +34,9 @@ export function ReadmePanel({ isOpen, onClose, repo, actionPrompt, autoRunAction
   const [input, setInput] = useState('');
   const [models, setModels] = useState<string[]>([]);
   const [selectedModel, setSelectedModel] = useState('local-model');
+  const [runtimeTarget, setRuntimeTarget] = useState(() =>
+    resolveRuntimeTarget(loadRuntimeSettings())
+  );
   const [overlayVisible, setOverlayVisible] = useState(false);
   const [overlayTitle, setOverlayTitle] = useState('');
   const [overlayContent, setOverlayContent] = useState('');
@@ -90,7 +94,7 @@ export function ReadmePanel({ isOpen, onClose, repo, actionPrompt, autoRunAction
 
     streamRef.current?.abort();
     streamRef.current = streamOpenResponses({
-      endpoint: `${EVENT_BUS_URL}/chat`,
+      endpoint: `${runtimeTarget.busUrl}/chat`,
       body: {
         model: selectedModel || 'local-model',
         messages: buildConversation(prompt),
@@ -117,7 +121,7 @@ export function ReadmePanel({ isOpen, onClose, repo, actionPrompt, autoRunAction
         setOverlayContent(`Error: ${error.message}`);
       },
     });
-  }, [repo, selectedModel, buildConversation]);
+  }, [repo, selectedModel, buildConversation, runtimeTarget]);
 
   useEffect(() => {
     if (isOpen && repo) {
@@ -151,7 +155,7 @@ export function ReadmePanel({ isOpen, onClose, repo, actionPrompt, autoRunAction
 
   useEffect(() => {
     if (!isOpen) return;
-    fetch(`${EVENT_BUS_URL}/models?task_kind=llm`)
+    fetch(`${runtimeTarget.busUrl}/models?task_kind=llm`)
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
         const list = Array.isArray(data)
@@ -167,10 +171,29 @@ export function ReadmePanel({ isOpen, onClose, repo, actionPrompt, autoRunAction
         if (normalized.length > 0) {
           setModels(normalized);
           setSelectedModel((prev) => (normalized.includes(prev) ? prev : normalized[0] ?? prev));
+        } else {
+          setSelectedModel(runtimeTarget.model || 'local-model');
         }
       })
-      .catch(() => null);
-  }, [isOpen]);
+      .catch(() => {
+        setModels([]);
+        setSelectedModel(runtimeTarget.model || 'local-model');
+      });
+  }, [isOpen, runtimeTarget]);
+
+  useEffect(() => {
+    const applySettings = () => {
+      const next = resolveRuntimeTarget(loadRuntimeSettings());
+      setRuntimeTarget(next);
+      setSelectedModel(next.model || 'local-model');
+    };
+    window.addEventListener(SETTINGS_EVENT, applySettings);
+    window.addEventListener('storage', applySettings);
+    return () => {
+      window.removeEventListener(SETTINGS_EVENT, applySettings);
+      window.removeEventListener('storage', applySettings);
+    };
+  }, []);
 
   useEffect(() => {
     if (isOpen) {

--- a/src/components/RuntimeSettingsPanel.tsx
+++ b/src/components/RuntimeSettingsPanel.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from 'react';
+import { Settings2 } from 'lucide-react';
+import {
+  DEFAULT_RUNTIME_SETTINGS,
+  RuntimeMode,
+  RuntimeSettings,
+  loadRuntimeSettings,
+  saveRuntimeSettings,
+} from '../lib/settings';
+
+export function RuntimeSettingsPanel() {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState<RuntimeSettings>(DEFAULT_RUNTIME_SETTINGS);
+
+  useEffect(() => {
+    setDraft(loadRuntimeSettings());
+  }, []);
+
+  const updateField = <K extends keyof RuntimeSettings>(key: K, value: RuntimeSettings[K]) => {
+    setDraft((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const save = () => {
+    saveRuntimeSettings(draft);
+    setOpen(false);
+  };
+
+  const reset = () => {
+    setDraft(DEFAULT_RUNTIME_SETTINGS);
+    saveRuntimeSettings(DEFAULT_RUNTIME_SETTINGS);
+  };
+
+  return (
+    <div className="runtime-settings">
+      <button
+        type="button"
+        className="runtime-settings__toggle"
+        onClick={() => setOpen((prev) => !prev)}
+        title="Runtime settings"
+      >
+        <Settings2 size={16} /> Runtime
+      </button>
+
+      {open && (
+        <div className="runtime-settings__panel">
+          <h3>Runtime settings</h3>
+          <p>Use local mode for MLX. Switch to web mode for remote/free API tests.</p>
+
+          <label>
+            Mode
+            <select
+              value={draft.mode}
+              onChange={(e) => updateField('mode', e.target.value as RuntimeMode)}
+            >
+              <option value="local">Local (MLX)</option>
+              <option value="web">Web API</option>
+            </select>
+          </label>
+
+          <label>
+            Local model
+            <input
+              value={draft.localModel}
+              onChange={(e) => updateField('localModel', e.target.value)}
+              placeholder="local-model"
+            />
+          </label>
+
+          <label>
+            Local bus URL
+            <input
+              value={draft.localBusUrl}
+              onChange={(e) => updateField('localBusUrl', e.target.value)}
+              placeholder="/bus"
+            />
+          </label>
+
+          <label>
+            Web model
+            <input
+              value={draft.webModel}
+              onChange={(e) => updateField('webModel', e.target.value)}
+              placeholder="gemini-2.5-flash"
+            />
+          </label>
+
+          <label>
+            Web bus URL
+            <input
+              value={draft.webBusUrl}
+              onChange={(e) => updateField('webBusUrl', e.target.value)}
+              placeholder="https://your-web-bus.example.com"
+            />
+          </label>
+
+          <div className="runtime-settings__actions">
+            <button type="button" onClick={save}>Save</button>
+            <button type="button" onClick={reset} className="ghost">Reset</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -621,6 +621,86 @@ body.panel-open #reposContainer {
   display: block;
 }
 
+.runtime-settings {
+  position: relative;
+}
+
+.runtime-settings__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid #d7dce3;
+  background: #fff;
+  color: #334155;
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.runtime-settings__panel {
+  position: absolute;
+  top: 38px;
+  right: 0;
+  width: 320px;
+  background: #fff;
+  border: 1px solid #d7dce3;
+  border-radius: 12px;
+  box-shadow: 0 18px 50px rgba(15, 23, 42, 0.18);
+  padding: 14px;
+  z-index: 1200;
+  display: grid;
+  gap: 10px;
+}
+
+.runtime-settings__panel h3 {
+  margin: 0;
+  font-size: 15px;
+}
+
+.runtime-settings__panel p {
+  margin: 0;
+  font-size: 12px;
+  color: #64748b;
+}
+
+.runtime-settings__panel label {
+  display: grid;
+  gap: 6px;
+  font-size: 12px;
+  color: #334155;
+}
+
+.runtime-settings__panel input,
+.runtime-settings__panel select {
+  border: 1px solid #d7dce3;
+  border-radius: 8px;
+  padding: 8px;
+  font-size: 13px;
+}
+
+.runtime-settings__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.runtime-settings__actions button {
+  border: 1px solid #cbd5e1;
+  background: #0f172a;
+  color: #fff;
+  border-radius: 8px;
+  padding: 7px 11px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.runtime-settings__actions button.ghost {
+  background: #fff;
+  color: #0f172a;
+}
+
 /* Logs Page */
 .logs-list {
   padding: 80px 20px;

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,0 +1,72 @@
+import { EVENT_BUS_URL } from './orchestrator';
+
+export type RuntimeMode = 'local' | 'web';
+
+export interface RuntimeSettings {
+  mode: RuntimeMode;
+  localModel: string;
+  webModel: string;
+  localBusUrl: string;
+  webBusUrl: string;
+}
+
+export const SETTINGS_STORAGE_KEY = 'git-stars:runtime-settings';
+export const SETTINGS_EVENT = 'git-stars:settings-changed';
+
+export const DEFAULT_RUNTIME_SETTINGS: RuntimeSettings = {
+  mode: 'local',
+  localModel: 'local-model',
+  webModel: 'gemini-2.5-flash',
+  localBusUrl: EVENT_BUS_URL,
+  webBusUrl: EVENT_BUS_URL,
+};
+
+function normalizeBusUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return EVENT_BUS_URL;
+  return trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed;
+}
+
+export function loadRuntimeSettings(): RuntimeSettings {
+  if (typeof window === 'undefined') {
+    return DEFAULT_RUNTIME_SETTINGS;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(SETTINGS_STORAGE_KEY);
+    if (!raw) return DEFAULT_RUNTIME_SETTINGS;
+    const parsed = JSON.parse(raw) as Partial<RuntimeSettings>;
+    return {
+      mode: parsed.mode === 'web' ? 'web' : 'local',
+      localModel: parsed.localModel || DEFAULT_RUNTIME_SETTINGS.localModel,
+      webModel: parsed.webModel || DEFAULT_RUNTIME_SETTINGS.webModel,
+      localBusUrl: normalizeBusUrl(parsed.localBusUrl || DEFAULT_RUNTIME_SETTINGS.localBusUrl),
+      webBusUrl: normalizeBusUrl(parsed.webBusUrl || DEFAULT_RUNTIME_SETTINGS.webBusUrl),
+    };
+  } catch {
+    return DEFAULT_RUNTIME_SETTINGS;
+  }
+}
+
+export function saveRuntimeSettings(settings: RuntimeSettings) {
+  if (typeof window === 'undefined') return;
+  const normalized: RuntimeSettings = {
+    mode: settings.mode,
+    localModel: settings.localModel.trim() || DEFAULT_RUNTIME_SETTINGS.localModel,
+    webModel: settings.webModel.trim() || DEFAULT_RUNTIME_SETTINGS.webModel,
+    localBusUrl: normalizeBusUrl(settings.localBusUrl),
+    webBusUrl: normalizeBusUrl(settings.webBusUrl),
+  };
+  window.localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(normalized));
+  window.dispatchEvent(new CustomEvent(SETTINGS_EVENT, { detail: normalized }));
+}
+
+export function resolveRuntimeTarget(settings: RuntimeSettings) {
+  const isWeb = settings.mode === 'web';
+  const busUrl = isWeb ? settings.webBusUrl : settings.localBusUrl;
+  return {
+    busUrl,
+    model: isWeb ? settings.webModel : settings.localModel,
+    mode: settings.mode,
+  };
+}


### PR DESCRIPTION
### Motivation
- Allow switching between local and web runtimes and configure model and event-bus endpoints at runtime to facilitate testing and flexible deployments.
- Ensure chat and README analysis flows can target the configured runtime and model rather than a hard-coded bus or model.

### Description
- Add `src/lib/settings.ts` which defines `RuntimeSettings`, provides `loadRuntimeSettings`, `saveRuntimeSettings`, `resolveRuntimeTarget`, and emits a `SETTINGS_EVENT` on changes.
- Add a new `RuntimeSettingsPanel` component at `src/components/RuntimeSettingsPanel.tsx` and styles in `src/css/main.css` to expose mode, model and bus URL configuration and save/reset actions.
- Integrate runtime settings into the app by rendering `<RuntimeSettingsPanel />` in the header and updating `ChatPanel` and `ReadmePanel` to load/observe runtime settings, use `runtimeTarget.busUrl` and `runtimeTarget.model` for API calls, and react to `SETTINGS_EVENT` and `storage` changes.
- Adjust imports and effect dependencies in `ChatPanel` and `ReadmePanel` and fall back to sensible defaults when model discovery fails.

### Testing
- Performed a TypeScript build/type-check (`yarn build` / `tsc`) to validate types and bundling and it completed successfully.
- No automated unit tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1f4f032a083209f5c58ae37685072)