### PR TITLE
Vega observatory Core-X contract bridge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,3 +60,11 @@
 - Active mission targets are Codex, Claude, and local MLX. Jules is historical template vocabulary, not a Vega Lab target.
 - Automations may draft action items, Ops kits, and mission briefs only. Do not open PRs, merge, deploy, or mutate other repositories without explicit human approval.
 - Public-facing summaries, SKILL candidates, technology alerts, and house ideas must pass human review before publication or adoption.
+
+## Current Operating Plan (2026-06-12)
+
+- **Observatory Restored:** Re-emphasize star/repo tracking alongside the skills-orchestrator pattern. Vega-Lab tracks personal owned, starred, and external watched repos to feed capability refinery flows.
+- **Review Gates Enforced:** Raw repo signals, source snapshots, and knowledge refinery artifacts must be generated as internal/draft files under `data/review/` or `data/` and mirrored to `public/`. Auto-promotion of capabilities is prohibited; promotion requires a distinct reviewed execution step.
+- **Parked Work Boundary:** Codex release hygiene and external repo mutations are parked. Do not modify or push changes to other houses or the main repository root.
+- **Evidence Curation:** Utilize OCR at `/v1/ocr/*` solely for visual evidence extraction from screenshots and diagrams. Do not use OCR as a general dialogue runtime.
+- **Reference Docs:** Refer to [agent-briefing-current-plan.md](docs/agent-briefing-current-plan.md) and [repo-star-observatory-audit-2026-06-12.md](docs/repo-star-observatory-audit-2026-06-12.md) for identity, contracts, and architecture definitions.

--- a/docs/agent-briefing-current-plan.md
+++ b/docs/agent-briefing-current-plan.md
@@ -1,0 +1,78 @@
+# Vega-Lab Agent Briefing — Current Plan
+
+## Identity
+
+Vega-Lab is Core-X's local-first repository observatory, capability refinery, and draft-only repository operations center. It runs local-first OpenResponses through the Core-X Gateway, utilizing text analytics and OCR-based visual evidence (diagrams, tables, screenshots, PDFs) to identify and package capability candidates.
+
+## Original Purpose
+
+Originally named `git-stars`, Vega-Lab existed to help David track:
+- Personal owned and collaborative repositories.
+- Starred repositories of interest.
+- External research/technology signals worth turning into Core-X skills, flows, tools, or research briefs.
+- Repository health and basic maintenance needs.
+
+## Updated Purpose
+
+Vega-Lab's original tracking capability now serves as the ingestion stage for Core-X's skills-orchestrator pattern. Repository discovery and star events feed a review-gated pipeline:
+```text
+source/repo discovery
+-> source snapshot / repo pack (Repomix-style)
+-> knowledge refinement (Skill Seekers-style, drift/conflict checks)
+-> reviewed capability proposal (skills, flows, tools, docs, house-capabilities)
+-> human-approved promotion into Core-X registries or house folders
+```
+
+## What Vega-Lab Owns
+
+- **Watched-source triage:** Curation and priority scoring of owned, starred, and watched repositories.
+- **Source snapshot records:** Ignore-aware metadata snapshots and token estimates of source packages.
+- **Knowledge-refinery artifacts:** Derivation of capabilities, risks, and potential drift/conflicts from source code and README analysis.
+- **Draft capability proposals:** Scaffolding `SKILL.md`, `RULES.md`, `WORKFLOWS.md`, or tool descriptors for human review.
+- **Non-mutating repository operations:** Drafting readiness checks, README updates, maintenance checklists, and internal Action Items.
+
+## What Vega-Lab Does Not Own
+
+- **Automatic promotion:** Direct mutation of Core-X registries, active skills, or house configurations.
+- **PRs, commits, and deploys:** Vega-Lab must never autonomously push commits, merge, deploy, or create houses in other workspaces.
+- **Shared resource custody:** Model weights/metadata belong to Model Zoo, asset storage to Warehouse, and archives to Anthology.
+
+## Current Core-X Contracts
+
+Vega-Lab outputs must conform to the following shared Core-X contracts:
+- **Architecture doc:** `core-x/docs/architecture/vega-lab-skills-orchestrator.md`
+- **Schemas:**
+  - `core-x/schemas/corex.source-snapshot.schema.json`
+  - `core-x/schemas/corex.knowledge-refinery-artifact.schema.json`
+  - `core-x/schemas/corex.capability-promotion-proposal.schema.json`
+- **Flows:**
+  - `core-x/flows/vega/source-snapshot.flow.yaml`
+  - `core-x/flows/vega/capability-promotion-review.flow.yaml`
+
+## Repo / Star Tracking Status
+
+- **GitHub CLI Integration:** Fully authenticated as user `KBLLR` (scopes: `gist`, `read:org`, `repo`, `workflow`). Remote API queries are active and safe.
+- **Cache Locations:** Starred repositories cached in [data.json](../data/data.json); owned repositories cached in [my-repos.json](../data/my-repos.json) (both mirrored in `public/`).
+- **Scoring Pipeline:** `house-model.js` computes an `adoptionScore` (0-100) based on repository stars, forks, license status, staleness, README presence, and capability keywords.
+
+## Audio Lab Proof-House Status
+
+Audio Lab is the first clean proof-house candidate for Vega-Lab's skills-orchestrator pattern. Its music, speech, and audio-asset pipelines are prime candidates for reusable capability extraction. However, this work is pending final owner approval for asset boundaries and privacy reviews. Do not modify Audio Lab source code or assets.
+
+## Codex Parked Work
+
+Codex release hygiene and automated workspace mutations are parked. Do not attempt Codex release tasks, do not push to origin, and do not stage unrelated dirty files at the repository root.
+
+## What To Do Next
+
+1. Run sync commands safely using authenticated credentials to update the starred and owned repository caches.
+2. Generate draft capability proposals for high-scoring repositories (Adoption Score >= 80) and place them in the draft/review directories (`data/review/`).
+3. Leverage the OCR engine (`/bus/v1/ocr/*`) for scanning repository screenshots, UI mockups, and architectural diagrams to extract skill candidates.
+
+## What Not To Do
+
+- **Do not push** changes to origin.
+- **Do not mutate** Audio Lab, HY-Motion, or Rigging Palace.
+- **Do not auto-apply** proposals to active registries or source directories.
+- **Do not edit** generated json registries by hand.
+- **Do not stage or commit** unrelated dirty files (e.g. `docs/ocr-runtime.md`, `pnpm-workspace.yaml`, or root-level changes).

--- a/docs/public-positioning.md
+++ b/docs/public-positioning.md
@@ -1,0 +1,34 @@
+# Vega-Lab Public Positioning
+
+## Short Description
+
+Vega-Lab is Core-X's observatory and capability refinery. It studies repositories, models, tools, papers, and house work, then drafts reviewed proposals for reusable skills, flows, tools, docs, and house capabilities.
+
+## Public-Safe Message
+
+Vega-Lab helps Core-X learn from the broader technical universe without surrendering local control. It keeps source discovery, evidence extraction, and capability proposals review-gated, local-first, and traceable.
+
+## What To Avoid Claiming
+
+- Do not claim Vega-Lab autonomously maintains other repositories.
+- Do not claim generated skill candidates are automatically published.
+- Do not claim public release readiness for every house.
+- Do not expose local runtime paths, private data, or raw snapshots.
+- Do not describe OCR as a chat runtime; OCR is for visual and document evidence only.
+
+## Relationship To Audio Lab
+
+Audio Lab is the first future proof house for Vega-Lab's skills-orchestrator pattern. Its audio, voice, diarisation, and asset workflows are good candidates for reusable capability packaging after source and asset boundaries are reviewed.
+
+## Relationship To Core-X
+
+Core-X supplies the shared runtime discipline:
+
+- OpenResponses for LLM interaction
+- A2A event bus for house/service events
+- Model Zoo for model governance
+- Warehouse for artifact custody
+- Anthology for archive and compilation
+- review artifacts and evidence bundles for promotion gates
+
+Vega-Lab proposes improvements into that system; it does not bypass it.

--- a/docs/repo-star-observatory-audit-2026-06-12.md
+++ b/docs/repo-star-observatory-audit-2026-06-12.md
@@ -1,0 +1,79 @@
+# Vega-Lab Repo/Star Observatory Audit — 2026-06-12
+
+## Current Repo Tracking Surfaces
+
+Owned and collaborative repositories are tracked locally using:
+- **Cache File:** [my-repos.json](../data/my-repos.json) (and its public mirror [public/my-repos.json](../public/my-repos.json)).
+- **Sync Script:** [my-repos.js](../scripts/my-repos.js), which queries the authenticated user's repositories, checks for README presence, maps package managers (`package.json`, lockfiles), and scans for CI workflows (`.github/workflows`) or deployment settings (`vercel.json`, `netlify.toml`).
+
+## Current Star Tracking Surfaces
+
+Starred repositories are tracked using:
+- **Cache File:** [data.json](../data/data.json) (and public mirror [public/data.json](../public/data.json)).
+- **Sync Implementation:** [github-sync.ts](../src/server/github-sync.ts), which queries the GitHub starred API endpoint, checks rate limits, paginates up to `maxPages`, and outputs internal artifacts per repository in `data/review/star-sync/`.
+
+## GitHub / MCP / gh CLI Readiness
+
+- **gh CLI Status:** Authenticated as user `KBLLR` (scopes: `gist`, `read:org`, `repo`, `workflow`). Keyring and `GH_TOKEN` environment variables are correctly configured and working.
+- **MCP Server:** [index.js](../mcp-server/index.js) implements the `vega-lab-mcp` server, exposing typed tools for listing, searching, filtering, and performing skill extraction and repo ops.
+- **OCR Engine Status:** Accessible at `/v1/ocr/*` or `/bus/v1/ocr/*`, utilizing `mlx-vision` for document and layout analysis of diagrams, tables, and screenshots.
+
+## Existing Watchlists
+
+- **Research Queue:** [research-queue.json](../data/research-queue.json) is used to track repositories flagged for deeper investigation.
+- **Repo Signals:** [repo-signals.json](../data/repo-signals.json) caches computed scores, matched capabilities, and recommended adoption kinds.
+
+## Missing Pieces
+
+1. **Drift Detection:** Lack of automated diff checks between the local repository snapshot/pack state and remote updates.
+2. **Schema Integration:** The sync scripts output raw repository objects and internal review logs but do not yet map directly to the newly introduced Core-X contracts like `corex.source-snapshot`.
+3. **Approval Interface:** The UI contains panels for review and inbox elements, but requires a structured action loop to transition a candidate from "reviewed proposal" to "promoted registry item".
+
+## Recommended Data Model
+
+For unified tracking and refinery triage, the following data model is recommended:
+```json
+{
+  "repo_id": "string (unique ID)",
+  "source_kind": "string (owned | starred | watched | manual | internal-house)",
+  "owner": "string (owner username)",
+  "name": "string (repo name)",
+  "url": "string (html URL)",
+  "visibility": "string (public | private)",
+  "primary_language": "string",
+  "description": "string",
+  "topics": ["string"],
+  "updated_at": "string (ISO timestamp)",
+  "last_seen_at": "string (ISO timestamp)",
+  "local_interest_score": "number (0-100)",
+  "corex_relevance": "string (high | medium | low)",
+  "matched_house": "string (optional matched house ID)",
+  "candidate_capabilities": ["string"],
+  "risk_flags": ["string"],
+  "review_status": "string (pending | accepted | dismissed)",
+  "snapshot_status": "string (none | captured | stale)",
+  "promotion_status": "string (none | proposed | promoted)"
+}
+```
+
+## Recommended Next Sync Flow
+
+```text
+GitHub owned/starred repo sync
+-> local repo/star cache (my-repos.json / data.json)
+-> repo scoring (house-model.js)
+-> source snapshot candidates (corex.source-snapshot.schema.json)
+-> knowledge refinery artifacts (corex.knowledge-refinery-artifact.schema.json)
+-> capability promotion proposals (corex.capability-promotion-proposal.schema.json)
+-> human review (UI / CLI permit loop)
+```
+
+## Risks
+
+- **API Rate Limiting:** Large-scale fetching of READMEs and sub-files (e.g. package.json) can trigger rate limits if unauthenticated (mitigated by using `gh` CLI auth).
+- **Public/Private Boundaries:** Accidentally snapshotting private repository contents and writing them to public-facing documentation or shared registries.
+- **Ecosystem Drift:** Re-extracting capabilities from repositories whose APIs or architectures have evolved, leading to broken/stale local skill files.
+
+## Next Agent Mission
+
+Integrate Vega-Lab's caching scripts (`github-sync.ts` and `my-repos.js`) with the Core-X schemas. Specifically, update the pipelines to generate `corex.source-snapshot` and `corex.knowledge-refinery-artifact` files under `data/review/` upon sync, ready for human-approved promotion.

--- a/docs/skills-orchestrator.md
+++ b/docs/skills-orchestrator.md
@@ -1,0 +1,58 @@
+# Vega-Lab Skills Orchestrator
+
+Vega-Lab is the Core-X observatory and capability refinery. Its job is to turn source evidence into reviewed local capability proposals.
+
+## Pipeline
+
+```text
+source/repo discovery
+-> source snapshot / repo pack
+-> knowledge refinement
+-> drift and conflict detection
+-> skill / flow / tool proposal
+-> review artifact
+-> human approval
+-> promotion into Core-X registry, docs, or house capability
+```
+
+## Vega-Lab Owns
+
+- source discovery and triage
+- repo/source snapshot records
+- knowledge-refinery artifacts
+- skill, flow, tool, doc, agent, and house-capability proposals
+- technology alerts
+- review-gated evidence packs
+
+## Vega-Lab Does Not Own
+
+- automatic promotion
+- direct mutation of other houses
+- automatic pull requests
+- deployments
+- public editorial publishing
+- model metadata ownership
+- Warehouse artifact custody
+
+## External Patterns To Absorb
+
+- Repomix: repo packing, ignore-aware snapshots, token estimates, secret-safety prechecks.
+- Skill Seekers: source normalization, diagnostics, progressive disclosure, conflict detection, refinery outputs.
+- AI Research Skills: later review for skillpack anatomy, bootstrap patterns, and research-skill distribution.
+
+## Draft Output Locations
+
+Generated review artifacts stay internal and pending. Existing OCR evidence and skill-candidate outputs remain under `data/review/**` only when explicitly requested.
+
+Promotion into Core-X registries, docs, or house capabilities must happen in a separate reviewed execution step.
+
+## Core-X Contract
+
+The shared Core-X side is documented in:
+
+- `core-x/docs/architecture/vega-lab-skills-orchestrator.md`
+- `core-x/schemas/corex.source-snapshot.schema.json`
+- `core-x/schemas/corex.knowledge-refinery-artifact.schema.json`
+- `core-x/schemas/corex.capability-promotion-proposal.schema.json`
+- `core-x/flows/vega/source-snapshot.flow.yaml`
+- `core-x/flows/vega/capability-promotion-review.flow.yaml`

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
     "build:data": "node scripts/generator.js",
     "sync:mine": "node scripts/my-repos.js",
     "sync:model-zoo": "node scripts/model-zoo-snapshot.js",
+    "export:corex-contracts": "node scripts/export-corex-contracts.js",
     "generate:stats": "node src/analytics/statistics.js",
     "mcp": "node src/mcp-server/index.js",
     "test:data": "node tests/run-tests.js",
     "test:mcp": "node tests/test-mcp-server.js && node tests/test-ocr-skill-candidate.js",
+    "test:corex-contract-export": "node tests/test-corex-contract-export.js",
     "test": "npm run lint && npm run test:data && npm run test:mcp"
   },
   "dependencies": {

--- a/scripts/export-corex-contracts.js
+++ b/scripts/export-corex-contracts.js
@@ -1,0 +1,378 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, "..");
+
+const GENERATED_BY = "vega-lab:export-corex-contracts";
+const TOOL = {
+  tool_id: "vega.export_corex_contracts",
+  name: "Vega Core-X Contract Exporter",
+  version: "0.1.0",
+};
+
+function toArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function slug(value) {
+  return String(value || "unknown")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "") || "unknown";
+}
+
+function repoNwo(repo) {
+  return repo?.nwo || [repo?.author, repo?.name].filter(Boolean).join("/") || "unknown/unknown";
+}
+
+function sourceUri(repo) {
+  return repo?.url || `https://github.com/${repoNwo(repo)}`;
+}
+
+function repoKey(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    limit: 25,
+    all: false,
+    dryRun: false,
+    scope: "all",
+    projectRoot,
+    outDir: path.join(projectRoot, "data", "review"),
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--all") {
+      options.all = true;
+    } else if (arg === "--dry-run") {
+      options.dryRun = true;
+    } else if (arg === "--limit") {
+      options.limit = Number.parseInt(argv[index + 1] || "", 10);
+      index += 1;
+    } else if (arg.startsWith("--limit=")) {
+      options.limit = Number.parseInt(arg.slice("--limit=".length), 10);
+    } else if (arg === "--scope") {
+      options.scope = argv[index + 1] || options.scope;
+      index += 1;
+    } else if (arg.startsWith("--scope=")) {
+      options.scope = arg.slice("--scope=".length);
+    } else if (arg === "--out-dir") {
+      options.outDir = path.resolve(options.projectRoot, argv[index + 1] || options.outDir);
+      index += 1;
+    } else if (arg.startsWith("--out-dir=")) {
+      options.outDir = path.resolve(options.projectRoot, arg.slice("--out-dir=".length));
+    } else if (arg === "--project-root") {
+      options.projectRoot = path.resolve(argv[index + 1] || options.projectRoot);
+      if (options.outDir === path.join(projectRoot, "data", "review")) {
+        options.outDir = path.join(options.projectRoot, "data", "review");
+      }
+      index += 1;
+    } else if (arg.startsWith("--project-root=")) {
+      options.projectRoot = path.resolve(arg.slice("--project-root=".length));
+      if (options.outDir === path.join(projectRoot, "data", "review")) {
+        options.outDir = path.join(options.projectRoot, "data", "review");
+      }
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!Number.isFinite(options.limit) || options.limit < 1) {
+    options.limit = 25;
+  }
+
+  return options;
+}
+
+async function readJson(root, relativePath, fallback = []) {
+  for (const prefix of ["data", "public"]) {
+    const filePath = path.join(root, prefix, relativePath);
+    try {
+      return JSON.parse(await fs.readFile(filePath, "utf8"));
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+  }
+  return fallback;
+}
+
+function indexByNwo(items) {
+  const map = new Map();
+  for (const item of toArray(items)) {
+    const nwo = repoKey(item?.nwo || repoNwo(item));
+    if (nwo) map.set(nwo, item);
+  }
+  return map;
+}
+
+function repoScope(repo, mineSet) {
+  return mineSet.has(repoKey(repoNwo(repo))) ? "mine" : "starred";
+}
+
+function selectRepos(repos, signalsByNwo, mineSet, options) {
+  const scope = String(options.scope || "all").toLowerCase();
+  const sorted = toArray(repos)
+    .map((repo) => ({ repo, signal: signalsByNwo.get(repoKey(repoNwo(repo))) || null, scope: repoScope(repo, mineSet) }))
+    .filter((entry) => scope === "all" || entry.scope === scope)
+    .sort((a, b) => {
+      const signalScore = (b.signal?.adoptionScore || 0) - (a.signal?.adoptionScore || 0);
+      if (signalScore !== 0) return signalScore;
+      const stars = (b.repo?.stars || 0) - (a.repo?.stars || 0);
+      if (stars !== 0) return stars;
+      return repoNwo(a.repo).localeCompare(repoNwo(b.repo));
+    });
+
+  return options.all ? sorted : sorted.slice(0, options.limit);
+}
+
+function tokenEstimate(repo, signal, extraction) {
+  const text = [
+    repo?.name,
+    repo?.author,
+    repo?.description,
+    toArray(repo?.topics).join(" "),
+    repo?.primary_language,
+    signal?.adoptionKind,
+    toArray(signal?.capabilities).join(" "),
+    extraction?.summary,
+  ].filter(Boolean).join(" ");
+  return Math.ceil(text.length / 4);
+}
+
+function buildSourceSnapshot({ repo, signal, extraction, scope, createdAt }) {
+  const nwo = repoNwo(repo);
+  const id = `vega:source-snapshot:${slug(nwo)}`;
+  const artifactRef = `data/review/source-snapshots/${slug(nwo)}.json`;
+
+  return {
+    id,
+    source_type: "repository",
+    source_uri: sourceUri(repo),
+    source_ref: nwo,
+    created_at: createdAt,
+    created_by: GENERATED_BY,
+    tool: TOOL,
+    include_patterns: ["repo metadata", "repo signals", "skill extraction summary"],
+    exclude_patterns: ["raw source files", "README body", "private file contents", "tokens", "secrets"],
+    token_estimate: {
+      tokens: tokenEstimate(repo, signal, extraction),
+      method: "metadata-character-estimate/4",
+      confidence: "estimated",
+    },
+    secret_scan: {
+      status: "skipped",
+      tool: "metadata-only-export:no-source-content",
+      findings_count: 0,
+      redaction_applied: false,
+      report_ref: null,
+    },
+    provenance: {
+      source_refs: [
+        `${scope}:repo:${nwo}`,
+        "vega:data/data.json|data/my-repos.json",
+        "vega:data/repo-signals.json",
+        "vega:data/skill-extractions.json",
+      ],
+      derived_from: ["vega repo/star cache", "vega repo signals", "vega skill extractions"],
+      commit: null,
+      license: repo?.license || null,
+    },
+    artifact_ref: artifactRef,
+    review_status: "pending",
+    metadata: {
+      nwo,
+      name: repo?.name || null,
+      author: repo?.author || null,
+      scope,
+      description: repo?.description || null,
+      stars: repo?.stars || 0,
+      forks: repo?.forks || 0,
+      open_issues: repo?.open_issues || 0,
+      primary_language: repo?.primary_language || null,
+      topics: toArray(repo?.topics),
+      last_updated: repo?.last_updated || repo?.last_updated_at || null,
+      adoption_score: signal?.adoptionScore ?? null,
+      adoption_kind: signal?.adoptionKind || extraction?.adoptionKind || null,
+      private: repo?.private === true,
+    },
+  };
+}
+
+function riskRecords(repo, signal, extraction) {
+  const risks = [];
+  const nwo = repoNwo(repo);
+  if (repo?.private) {
+    risks.push({ summary: "Repository is private; keep analysis internal and metadata-only.", severity: "blocking", source_refs: [`repo:${nwo}`] });
+  }
+  if (!repo?.license || repo.license === "None") {
+    risks.push({ summary: "License is missing or unspecified; adoption requires manual license review.", severity: "warning", source_refs: [`repo:${nwo}`] });
+  }
+  if ((signal?.adoptionKind || extraction?.adoptionKind) === "ignore") {
+    risks.push({ summary: "Vega classified this repository as ignore; do not promote without explicit review.", severity: "warning", source_refs: [`signal:${nwo}`] });
+  }
+  return risks;
+}
+
+function conflictRecords(repo, signal, extraction) {
+  const conflicts = [];
+  const nwo = repoNwo(repo);
+  const capabilities = unique([...toArray(signal?.capabilities), ...toArray(extraction?.capabilities)]);
+  if (capabilities.includes("frontend-ui") && capabilities.includes("developer-tooling")) {
+    conflicts.push({ summary: "Capability overlaps existing frontend and developer-tooling lanes; promotion target must be specific.", kind: "capability_overlap", source_refs: [`repo:${nwo}`] });
+  }
+  if (repo?.license && /agpl/i.test(repo.license)) {
+    conflicts.push({ summary: "AGPL license detected; adoption may conflict with distribution goals.", kind: "license", source_refs: [`repo:${nwo}`] });
+  }
+  return conflicts;
+}
+
+function buildKnowledgeArtifact({ repo, signal, extraction, snapshot, scope, createdAt }) {
+  const nwo = repoNwo(repo);
+  const capabilities = unique([...toArray(signal?.capabilities), ...toArray(extraction?.capabilities)]);
+  const houseSkills = unique([...toArray(signal?.houseSkills), ...toArray(extraction?.houseSkills)]);
+  const adoptionKind = signal?.adoptionKind || extraction?.adoptionKind || "ignore";
+  const summary = extraction?.summary || signal?.description || repo?.description || `Repository metadata for ${nwo}.`;
+
+  return {
+    id: `vega:knowledge-refinery:${slug(nwo)}`,
+    snapshot_id: snapshot.id,
+    summary: `${nwo}: ${summary}`,
+    entities: [
+      { name: nwo, kind: "repository", source_refs: [`repo:${nwo}`] },
+      ...houseSkills.map((skill) => ({ name: skill, kind: "house-skill", source_refs: [`skill-extraction:${nwo}`] })),
+    ],
+    capabilities: capabilities.map((capability) => ({
+      id: `vega.capability.${slug(capability)}`,
+      label: capability,
+      description: `Detected Vega capability from repo metadata/signals: ${capability}`,
+      source_refs: [`repo:${nwo}`, `signal:${nwo}`],
+    })),
+    risks: riskRecords(repo, signal, extraction),
+    conflicts: conflictRecords(repo, signal, extraction),
+    extracted_skills: houseSkills.map((skill) => ({
+      id: `vega.skill-candidate.${slug(nwo)}.${slug(skill)}`,
+      name: skill,
+      source_repo: nwo,
+      review_status: "pending",
+    })),
+    extracted_flows: toArray(extraction?.flows).map((flow) => ({
+      id: `vega.flow-candidate.${slug(nwo)}.${slug(flow)}`,
+      name: flow,
+      source_repo: nwo,
+      review_status: "pending",
+    })),
+    confidence: Math.max(0.35, Math.min(0.9, ((signal?.adoptionScore || 50) / 100))),
+    provenance: {
+      source_refs: [`repo:${nwo}`, `snapshot:${snapshot.id}`],
+      evidence_refs: [
+        snapshot.artifact_ref,
+        `vega:data/repo-signals.json#${nwo}`,
+        `vega:data/skill-extractions.json#${nwo}`,
+      ],
+      derived_from: [snapshot.id, "vega repo signals", "vega skill extractions"],
+    },
+    review_status: "pending",
+    metadata: {
+      nwo,
+      scope,
+      adoption_kind: adoptionKind,
+      adoption_score: signal?.adoptionScore ?? null,
+      primary_language: repo?.primary_language || null,
+      topics: toArray(repo?.topics),
+      generated_by: GENERATED_BY,
+      created_at: createdAt,
+    },
+  };
+}
+
+async function writeArtifacts(outDir, pairs) {
+  const snapshotDir = path.join(outDir, "source-snapshots");
+  const refineryDir = path.join(outDir, "knowledge-refinery");
+  await fs.mkdir(snapshotDir, { recursive: true });
+  await fs.mkdir(refineryDir, { recursive: true });
+
+  for (const pair of pairs) {
+    const safeName = slug(pair.nwo);
+    await fs.writeFile(path.join(snapshotDir, `${safeName}.json`), `${JSON.stringify(pair.sourceSnapshot, null, 2)}\n`, "utf8");
+    await fs.writeFile(path.join(refineryDir, `${safeName}.json`), `${JSON.stringify(pair.knowledgeArtifact, null, 2)}\n`, "utf8");
+  }
+}
+
+export async function buildCorexContractArtifacts(options = {}) {
+  const root = options.projectRoot || projectRoot;
+  const createdAt = options.createdAt || new Date().toISOString();
+  const starredRepos = await readJson(root, "data.json", []);
+  const myRepos = await readJson(root, "my-repos.json", []);
+  const repoSignals = await readJson(root, "repo-signals.json", []);
+  const skillExtractions = await readJson(root, "skill-extractions.json", []);
+
+  const signalsByNwo = indexByNwo(repoSignals);
+  const extractionsByNwo = indexByNwo(skillExtractions);
+  const mineSet = new Set(toArray(myRepos).map((repo) => repoKey(repoNwo(repo))));
+  const allReposByNwo = new Map();
+
+  for (const repo of [...toArray(myRepos), ...toArray(starredRepos)]) {
+    const nwo = repoKey(repoNwo(repo));
+    if (nwo && !allReposByNwo.has(nwo)) allReposByNwo.set(nwo, repo);
+  }
+
+  const selected = selectRepos([...allReposByNwo.values()], signalsByNwo, mineSet, options);
+  const artifacts = selected.map(({ repo, signal, scope }) => {
+    const extraction = extractionsByNwo.get(repoKey(repoNwo(repo))) || null;
+    const sourceSnapshot = buildSourceSnapshot({ repo, signal, extraction, scope, createdAt });
+    const knowledgeArtifact = buildKnowledgeArtifact({ repo, signal, extraction, snapshot: sourceSnapshot, scope, createdAt });
+    return { nwo: repoNwo(repo), sourceSnapshot, knowledgeArtifact };
+  });
+
+  return {
+    generated_by: GENERATED_BY,
+    created_at: createdAt,
+    dry_run: options.dryRun === true,
+    selected_count: artifacts.length,
+    available_count: allReposByNwo.size,
+    outputs: {
+      source_snapshots: path.relative(root, path.join(options.outDir || path.join(root, "data", "review"), "source-snapshots")),
+      knowledge_refinery: path.relative(root, path.join(options.outDir || path.join(root, "data", "review"), "knowledge-refinery")),
+    },
+    artifacts,
+  };
+}
+
+export async function runExport(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  const result = await buildCorexContractArtifacts(options);
+
+  if (!options.dryRun) {
+    await writeArtifacts(options.outDir, result.artifacts);
+  }
+
+  const summary = {
+    generated_by: result.generated_by,
+    created_at: result.created_at,
+    dry_run: result.dry_run,
+    selected_count: result.selected_count,
+    available_count: result.available_count,
+    outputs: result.outputs,
+  };
+  console.log(JSON.stringify(summary, null, 2));
+  return result;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runExport().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/tests/test-corex-contract-export.js
+++ b/tests/test-corex-contract-export.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { buildCorexContractArtifacts, runExport } from "../scripts/export-corex-contracts.js";
+
+async function writeJson(filePath, data) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+}
+
+async function exists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  const originalCwd = process.cwd();
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "vega-corex-contract-export-"));
+
+  const repo = {
+    name: "demo-repo",
+    author: "example",
+    description: "A deterministic repo intelligence demo.",
+    url: "https://github.com/example/demo-repo",
+    stars: 120,
+    forks: 7,
+    open_issues: 2,
+    primary_language: "TypeScript",
+    topics: ["agent", "workflow"],
+    license: "MIT",
+  };
+
+  await writeJson(path.join(root, "data", "data.json"), [repo]);
+  await writeJson(path.join(root, "data", "my-repos.json"), []);
+  await writeJson(path.join(root, "data", "repo-signals.json"), [{
+    nwo: "example/demo-repo",
+    description: repo.description,
+    adoptionScore: 82,
+    adoptionKind: "tool",
+    capabilities: ["agent-workflows", "developer-tooling"],
+    houseSkills: ["repo-discovery", "skill-extraction"],
+  }]);
+  await writeJson(path.join(root, "data", "skill-extractions.json"), [{
+    nwo: "example/demo-repo",
+    summary: "Useful agent workflow repository.",
+    capabilities: ["agent-workflows"],
+    houseSkills: ["skill-extraction"],
+    flows: ["research-queue-flow"],
+    adoptionKind: "tool",
+  }]);
+
+  try {
+    process.chdir(root);
+    const result = await buildCorexContractArtifacts({ projectRoot: root, dryRun: true, limit: 1, createdAt: "2026-06-12T00:00:00.000Z" });
+    assert.equal(result.selected_count, 1);
+    assert.equal(result.artifacts[0].sourceSnapshot.review_status, "pending");
+    assert.equal(result.artifacts[0].sourceSnapshot.secret_scan.status, "skipped");
+    assert.equal(result.artifacts[0].knowledgeArtifact.review_status, "pending");
+    assert.equal(result.artifacts[0].knowledgeArtifact.snapshot_id, result.artifacts[0].sourceSnapshot.id);
+    assert.ok(!JSON.stringify(result).includes("README body text"), "Export must not include README/source bodies");
+
+    const outDir = path.join(root, "data", "review");
+    await runExport(["--limit=1", `--project-root=${root}`, `--out-dir=${outDir}`]);
+    assert.ok(await exists(path.join(outDir, "source-snapshots", "example-demo-repo.json")));
+    assert.ok(await exists(path.join(outDir, "knowledge-refinery", "example-demo-repo.json")));
+  } finally {
+    process.chdir(originalCwd);
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error("Core-X contract export test failed");
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Documents Vega-Lab's skills orchestrator and observatory positioning.
- Adds a narrow offline Core-X contract exporter for repo signal review artifacts.
- Adds a focused exporter test and minimal package scripts.

## Scope
- Excludes dfac205 broad baseline changes.
- Excludes generated data/public JSON, lockfile changes, UI changes, and server changes.

## Verification
- rg leak scan for local file paths
- git diff --check
- npm run export:corex-contracts -- --dry-run --limit=2
- npm run test:corex-contract-export
- node --check scripts/export-corex-contracts.js
- node --check tests/test-corex-contract-export.js