### PR TITLE
Restore Vega pnpm install and production build

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+onlyBuiltDependencies:
+  - esbuild
+
+packages:
+  - .


### PR DESCRIPTION
## Summary
- Adds a minimal pnpm workspace build-approval file for esbuild.
- Restores non-interactive pnpm install and production build on current origin/main.

## Verification
- pnpm install
- pnpm run build
- git diff --check

## Scope note
The local dirty checkout also had TypeScript fixes for ReviewArtifact/ReviewPanel, but those broad Review UI files are not present on current origin/main. This PR intentionally does not import that unrelated UI baseline.