### PR TITLE
feat(vega): add review-gated skill candidate ingestion

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,13 @@
     "sync:mine": "node scripts/my-repos.js",
     "sync:model-zoo": "node scripts/model-zoo-snapshot.js",
     "export:corex-contracts": "node scripts/export-corex-contracts.js",
+    "build:skill-candidates": "node scripts/build-skill-candidates.js",
     "generate:stats": "node src/analytics/statistics.js",
     "mcp": "node src/mcp-server/index.js",
     "test:data": "node tests/run-tests.js",
     "test:mcp": "node tests/test-mcp-server.js && node tests/test-ocr-skill-candidate.js",
     "test:corex-contract-export": "node tests/test-corex-contract-export.js",
+    "test:skill-candidate-ingestion": "node tests/test-skill-candidate-ingestion.js",
     "test": "npm run lint && npm run test:data && npm run test:mcp"
   },
   "dependencies": {

--- a/scripts/build-skill-candidates.js
+++ b/scripts/build-skill-candidates.js
@@ -1,0 +1,800 @@
+#!/usr/bin/env node
+
+import crypto from "node:crypto";
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { buildCorexContractArtifacts } from "./export-corex-contracts.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, "..");
+
+const GENERATED_BY = "vega-lab:build-skill-candidates";
+const TOOL = {
+  tool_id: "vega.build_skill_candidates",
+  name: "Vega Skill Candidate Ingestion",
+  version: "0.1.0",
+};
+
+const SECRET_PATTERNS = [
+  new RegExp(["BEGIN", "[A-Z ]*", "PRIVATE", "KEY"].join(" "), "i"),
+  new RegExp("\\b" + "ghp" + "_[A-Za-z0-9_]{20,}\\b"),
+  new RegExp("\\b" + "sk" + "-[A-Za-z0-9_-]{20,}\\b"),
+  /\bapi[_-]?key\b\s*[:=]/i,
+  /\bsecret\b\s*[:=]/i,
+  /\btoken\b\s*[:=]/i,
+];
+
+const LOCAL_PATH_PATTERNS = [
+  /file:\/\/\/Users\//i,
+  /\/Users\/[A-Za-z0-9_.-]+/,
+  new RegExp("core-x-" + "kbllr_0"),
+];
+
+const UNSAFE_EXEC_PATTERNS = [
+  /curl\s+[^|]+\|\s*(bash|sh)/i,
+  /wget\s+[^|]+\|\s*(bash|sh)/i,
+  /rm\s+-rf\s+\//i,
+  /chmod\s+\+x/i,
+  /postinstall/i,
+];
+
+function toArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean).map((value) => String(value)))];
+}
+
+function slug(value) {
+  return String(value || "unknown")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "") || "unknown";
+}
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function existingDir(dirPath) {
+  try {
+    return fsSync.statSync(dirPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function detectCorexRoot(root) {
+  const candidates = [];
+  if (process.env.COREX_ROOT) candidates.push(path.resolve(process.env.COREX_ROOT));
+  candidates.push(path.resolve(root, "..", "..", "core-x"));
+
+  try {
+    const gitMarker = fsSync.readFileSync(path.join(root, ".git"), "utf8").trim();
+    const match = /^gitdir:\s*(.+)$/i.exec(gitMarker);
+    if (match) {
+      const gitDir = path.resolve(root, match[1]);
+      const commonGitDir = path.dirname(path.dirname(gitDir));
+      const originalHouseRoot = path.dirname(commonGitDir);
+      candidates.push(path.resolve(originalHouseRoot, "..", "..", "core-x"));
+    }
+  } catch {
+    // Non-worktree checkouts usually have a .git directory instead of a marker file.
+  }
+
+  return candidates.find((candidate) => existingDir(candidate)) || candidates[0];
+}
+
+function stableStringify(value) {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function repoNwoFromArtifact(pair) {
+  return pair?.nwo
+    || pair?.sourceSnapshot?.metadata?.nwo
+    || pair?.knowledgeArtifact?.metadata?.nwo
+    || pair?.sourceSnapshot?.source_ref
+    || "unknown/unknown";
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    limit: 25,
+    all: false,
+    dryRun: false,
+    emitDraftFolders: false,
+    scope: "all",
+    projectRoot,
+    outDir: path.join(projectRoot, "data", "review"),
+    corexRoot: process.env.COREX_ROOT || null,
+    createdAt: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--all") {
+      options.all = true;
+    } else if (arg === "--dry-run") {
+      options.dryRun = true;
+    } else if (arg === "--emit-draft-folders") {
+      options.emitDraftFolders = true;
+    } else if (arg === "--limit") {
+      options.limit = Number.parseInt(argv[index + 1] || "", 10);
+      index += 1;
+    } else if (arg.startsWith("--limit=")) {
+      options.limit = Number.parseInt(arg.slice("--limit=".length), 10);
+    } else if (arg === "--scope") {
+      options.scope = argv[index + 1] || options.scope;
+      index += 1;
+    } else if (arg.startsWith("--scope=")) {
+      options.scope = arg.slice("--scope=".length);
+    } else if (arg === "--project-root") {
+      options.projectRoot = path.resolve(argv[index + 1] || options.projectRoot);
+      index += 1;
+    } else if (arg.startsWith("--project-root=")) {
+      options.projectRoot = path.resolve(arg.slice("--project-root=".length));
+    } else if (arg === "--out-dir") {
+      options.outDir = path.resolve(argv[index + 1] || options.outDir);
+      index += 1;
+    } else if (arg.startsWith("--out-dir=")) {
+      options.outDir = path.resolve(arg.slice("--out-dir=".length));
+    } else if (arg === "--corex-root") {
+      options.corexRoot = path.resolve(argv[index + 1] || "");
+      index += 1;
+    } else if (arg.startsWith("--corex-root=")) {
+      options.corexRoot = path.resolve(arg.slice("--corex-root=".length));
+    } else if (arg === "--created-at") {
+      options.createdAt = argv[index + 1] || null;
+      index += 1;
+    } else if (arg.startsWith("--created-at=")) {
+      options.createdAt = arg.slice("--created-at=".length);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!Number.isFinite(options.limit) || options.limit < 1) options.limit = 25;
+  if (!options.corexRoot) options.corexRoot = detectCorexRoot(options.projectRoot);
+  options.outDir = path.resolve(options.outDir);
+  return options;
+}
+
+async function pathExists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJson(filePath, fallback = null) {
+  try {
+    return JSON.parse(await fs.readFile(filePath, "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") return fallback;
+    throw error;
+  }
+}
+
+async function readJsonFiles(dirPath) {
+  const results = [];
+  try {
+    const entries = await fs.readdir(dirPath, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        results.push(...await readJsonFiles(fullPath));
+      } else if (entry.name.endsWith(".json")) {
+        const value = await readJson(fullPath, null);
+        if (value) results.push({ filePath: fullPath, value });
+      }
+    }
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+  return results;
+}
+
+async function loadExistingSkillIndex(corexRoot) {
+  const skillIds = new Set();
+  const skillRecords = [];
+  if (!corexRoot || !await pathExists(corexRoot)) {
+    return { available: false, skillIds, skillRecords };
+  }
+
+  const skillsRoot = path.join(corexRoot, "skills");
+  try {
+    const entries = await fs.readdir(skillsRoot, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const id = entry.name;
+      skillIds.add(id);
+      const skillDir = path.join(skillsRoot, id);
+      const manifest = await readJson(path.join(skillDir, "manifest.json"), null);
+      const skillMdPath = path.join(skillDir, "SKILL.md");
+      let heading = id;
+      try {
+        const skillText = await fs.readFile(skillMdPath, "utf8");
+        const firstHeading = skillText.split("\n").find((line) => /^#\s+/.test(line));
+        if (firstHeading) heading = firstHeading.replace(/^#\s+/, "").trim();
+      } catch {
+        // Keep directory id as the fallback name.
+      }
+      const record = {
+        skill_id: manifest?.skill_id || manifest?.id || id,
+        name: manifest?.name || heading,
+        tools: toArray(manifest?.tools),
+        flows: toArray(manifest?.flows),
+        source_ref: path.relative(corexRoot, skillDir),
+      };
+      skillIds.add(record.skill_id);
+      skillRecords.push(record);
+    }
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+
+  return { available: true, skillIds, skillRecords };
+}
+
+async function loadExistingCandidates(projectRootValue, outDir) {
+  const dirs = [
+    path.join(projectRootValue, "data", "review", "skill-candidates"),
+    path.join(outDir, "skill-candidates"),
+  ];
+  const byId = new Map();
+  for (const dir of dirs) {
+    for (const record of await readJsonFiles(dir)) {
+      const id = record.value?.candidate_id || record.value?.id;
+      if (id && !byId.has(id)) byId.set(id, record.value);
+    }
+  }
+  return [...byId.values()];
+}
+
+function inferLane(knowledgeArtifact, snapshot) {
+  const text = [
+    knowledgeArtifact?.summary,
+    snapshot?.metadata?.primary_language,
+    toArray(snapshot?.metadata?.topics).join(" "),
+    toArray(knowledgeArtifact?.capabilities).map((capability) => capability.label || capability.id).join(" "),
+  ].join(" ").toLowerCase();
+
+  if (/3d|webgl|graphics|shader|vision|image|avatar|render/.test(text)) return "visual-runtime";
+  if (/agent|workflow|orchestr|automation|mcp|tool/.test(text)) return "agent-workflows";
+  if (/research|paper|dataset|benchmark|evaluation/.test(text)) return "research-intelligence";
+  if (/frontend|react|vite|ui|component/.test(text)) return "frontend-ui";
+  if (/deploy|infra|devops|database|server|cli/.test(text)) return "developer-tooling";
+  return "core-capability";
+}
+
+function inferScope(snapshot, knowledgeArtifact) {
+  if (snapshot?.metadata?.private === true) return "house-local";
+  if (knowledgeArtifact?.metadata?.adoption_kind === "house") return "house-local";
+  return "shared";
+}
+
+function inferRequiredToolsAndServices(lane, knowledgeArtifact) {
+  const tools = ["vega-lab:mcp", "vega-lab:repo-signals", "vega-lab:source-snapshot"];
+  const services = [];
+  if (lane === "agent-workflows") tools.push("core-x:openresponses", "core-x:event-bus");
+  if (lane === "research-intelligence") services.push("mlx-rag");
+  if (lane === "visual-runtime") services.push("mlx-vision", "ocr");
+  if (toArray(knowledgeArtifact?.extracted_flows).length > 0) tools.push("core-x:flows");
+  return { tools: unique(tools), services: unique(services) };
+}
+
+function licenseStatus(license) {
+  const value = String(license || "").trim();
+  if (!value || /^none$/i.test(value)) {
+    return { status: "unknown", review_required: true, notes: "Missing or unspecified license; requires manual review before adoption." };
+  }
+  if (/agpl/i.test(value)) {
+    return { status: "incompatible", review_required: true, notes: "AGPL-style license detected; promotion may conflict with distribution goals." };
+  }
+  if (/(gpl|lgpl)/i.test(value)) {
+    return { status: "restricted", review_required: true, notes: "GPL-family license detected; adoption scope must be reviewed." };
+  }
+  if (/(mit|apache|bsd|isc|mpl|unlicense|cc0)/i.test(value)) {
+    return { status: "compatible", review_required: false, notes: `License appears adoption-friendly: ${value}.` };
+  }
+  return { status: "review", review_required: true, notes: `License requires manual compatibility review: ${value}.` };
+}
+
+function textForScanning(candidateInput) {
+  return stableStringify(candidateInput);
+}
+
+function patternFindings(patterns, text, kind, severity = "blocking") {
+  return patterns
+    .filter((pattern) => pattern.test(text))
+    .map((pattern) => ({
+      kind,
+      severity,
+      summary: `${kind} indicator matched pattern ${String(pattern)}`,
+    }));
+}
+
+function tokenSimilarity(a, b) {
+  const aTokens = new Set(slug(a).split("-").filter((token) => token.length > 2));
+  const bTokens = new Set(slug(b).split("-").filter((token) => token.length > 2));
+  if (aTokens.size === 0 || bTokens.size === 0) return 0;
+  const overlap = [...aTokens].filter((token) => bTokens.has(token)).length;
+  return overlap / Math.max(aTokens.size, bTokens.size);
+}
+
+function duplicateMatches(candidate, existingSkillIndex, existingCandidates) {
+  const matches = [];
+  if (existingSkillIndex.skillIds.has(candidate.candidate_id) || existingSkillIndex.skillIds.has(candidate.suggested_skill_id)) {
+    matches.push({
+      kind: "duplicate_id",
+      target: candidate.suggested_skill_id,
+      confidence: 1,
+      source: "core-x/skills",
+    });
+  }
+
+  for (const skill of existingSkillIndex.skillRecords) {
+    const score = Math.max(
+      tokenSimilarity(candidate.name, skill.name),
+      tokenSimilarity(candidate.suggested_skill_id, skill.skill_id),
+    );
+    if (score >= 0.45) {
+      matches.push({
+        kind: "similar_existing_capability",
+        target: skill.skill_id,
+        label: skill.name,
+        confidence: Number(score.toFixed(2)),
+        source: skill.source_ref,
+      });
+    }
+  }
+
+  for (const existing of existingCandidates) {
+    if (existing.candidate_id === candidate.candidate_id) {
+      matches.push({
+        kind: "duplicate_id",
+        target: existing.candidate_id,
+        confidence: 1,
+        source: "vega:data/review/skill-candidates",
+      });
+    }
+  }
+
+  return matches;
+}
+
+function conflictFindings(candidate, knowledgeArtifact, existingSkillIndex) {
+  const findings = [];
+  for (const conflict of toArray(knowledgeArtifact?.conflicts)) {
+    findings.push({
+      kind: conflict.kind || "unknown",
+      severity: conflict.kind === "license" ? "blocking" : "warning",
+      summary: conflict.summary || "Knowledge refinery conflict requires review.",
+      source_refs: toArray(conflict.source_refs),
+    });
+  }
+
+  if (!existingSkillIndex.available) {
+    findings.push({
+      kind: "missing_reference_index",
+      severity: "warning",
+      summary: "Core-X skill index was not available; duplicate detection is partial.",
+      source_refs: ["core-x/skills"],
+    });
+  }
+
+  if (candidate.suggested_corex_lane === "visual-runtime" && !candidate.required_tools_services.services.includes("mlx-vision")) {
+    findings.push({
+      kind: "wrong_model_service_lane",
+      severity: "blocking",
+      summary: "Visual runtime candidates must declare the MLX Vision service lane.",
+      source_refs: candidate.provenance_references,
+    });
+  }
+
+  if (candidate.license_status.status === "unknown" || candidate.license_status.status === "incompatible") {
+    findings.push({
+      kind: "license",
+      severity: candidate.license_status.status === "incompatible" ? "blocking" : "warning",
+      summary: candidate.license_status.notes,
+      source_refs: candidate.provenance_references,
+    });
+  }
+
+  if (candidate.provenance_references.length === 0) {
+    findings.push({
+      kind: "missing_provenance",
+      severity: "blocking",
+      summary: "Candidate is missing provenance references.",
+      source_refs: [],
+    });
+  }
+
+  const scanText = textForScanning(candidate);
+  findings.push(...patternFindings(LOCAL_PATH_PATTERNS, scanText, "absolute_local_path"));
+  findings.push(...patternFindings(SECRET_PATTERNS, scanText, "secret_or_credential"));
+  findings.push(...patternFindings(UNSAFE_EXEC_PATTERNS, scanText, "unsafe_executable_script", "warning"));
+
+  return findings;
+}
+
+function riskFindings(candidate, knowledgeArtifact) {
+  const risks = toArray(knowledgeArtifact?.risks).map((risk) => ({
+    kind: risk.severity === "blocking" ? "blocking_risk" : "adoption_risk",
+    severity: risk.severity || "warning",
+    summary: risk.summary || "Knowledge refinery risk requires review.",
+    source_refs: toArray(risk.source_refs),
+  }));
+
+  if (candidate.duplicate_matches.length > 0) {
+    risks.push({
+      kind: "duplicate_review",
+      severity: "warning",
+      summary: "Candidate overlaps existing skills or pending candidates; review before promotion.",
+      source_refs: candidate.duplicate_matches.map((match) => match.source).filter(Boolean),
+    });
+  }
+  return risks;
+}
+
+function buildEvidenceSummary(knowledgeArtifact, snapshot) {
+  const capabilities = toArray(knowledgeArtifact?.capabilities)
+    .map((capability) => capability.label || capability.id)
+    .filter(Boolean)
+    .slice(0, 6);
+  const risks = toArray(knowledgeArtifact?.risks).map((risk) => risk.summary).filter(Boolean).slice(0, 3);
+  return [
+    knowledgeArtifact?.summary || snapshot?.metadata?.description || `Repository metadata for ${snapshot?.source_ref}.`,
+    capabilities.length > 0 ? `Capabilities: ${capabilities.join(", ")}.` : "Capabilities: no explicit capabilities detected.",
+    risks.length > 0 ? `Review risks: ${risks.join(" ")}` : "Review risks: no blocking metadata risk detected.",
+  ].join(" ");
+}
+
+function draftSkillMarkdown(candidate) {
+  return [
+    `# ${candidate.name}`,
+    "",
+    "## Purpose",
+    candidate.description,
+    "",
+    "## Source",
+    `- Repository: ${candidate.source_repository.nwo}`,
+    `- Snapshot: ${candidate.source_snapshot_identity.snapshot_id}`,
+    "",
+    "## Suggested Core-X Placement",
+    `- Lane: ${candidate.suggested_corex_lane}`,
+    `- Scope: ${candidate.suggested_scope}`,
+    "",
+    "## Evidence Summary",
+    candidate.evidence_summary,
+    "",
+    "## Review Gate",
+    "- Status: pending",
+    "- This is a draft candidate only. Do not promote without human approval.",
+    "",
+  ].join("\n");
+}
+
+function buildCandidate({ pair, existingSkillIndex, existingCandidates, createdAt }) {
+  const snapshot = pair.sourceSnapshot;
+  const knowledgeArtifact = pair.knowledgeArtifact;
+  const nwo = repoNwoFromArtifact(pair);
+  const safeRepo = slug(nwo);
+  const lane = inferLane(knowledgeArtifact, snapshot);
+  const scope = inferScope(snapshot, knowledgeArtifact);
+  const license = licenseStatus(snapshot?.provenance?.license || snapshot?.metadata?.license || null);
+  const required = inferRequiredToolsAndServices(lane, knowledgeArtifact);
+  const suggestedSkillId = `vega-${safeRepo}`;
+  const provenanceReferences = unique([
+    snapshot?.artifact_ref,
+    `vega:data/repo-signals.json#${nwo}`,
+    `vega:data/skill-extractions.json#${nwo}`,
+    ...toArray(knowledgeArtifact?.provenance?.source_refs),
+    ...toArray(knowledgeArtifact?.provenance?.evidence_refs),
+  ]);
+
+  const base = {
+    candidate_id: `vega.skill-candidate:${safeRepo}`,
+    suggested_skill_id: suggestedSkillId,
+    name: `${snapshot?.metadata?.name || nwo} Core-X Skill Candidate`,
+    description: knowledgeArtifact?.summary || snapshot?.metadata?.description || `Review-gated skill candidate for ${nwo}.`,
+    source_repository: {
+      nwo,
+      uri: snapshot?.source_uri || `https://github.com/${nwo}`,
+      scope: snapshot?.metadata?.scope || "unknown",
+      private: snapshot?.metadata?.private === true,
+    },
+    source_snapshot_identity: {
+      snapshot_id: snapshot?.id || null,
+      source_ref: snapshot?.source_ref || nwo,
+      artifact_ref: snapshot?.artifact_ref || null,
+    },
+    provenance_references: provenanceReferences,
+    suggested_corex_lane: lane,
+    suggested_scope: scope,
+    required_tools_services: required,
+    license_status: license,
+    compatibility_assumptions: [
+      "Generated from Vega metadata, repo signals, and skill extraction cache only.",
+      "No third-party source code or long README bodies are copied into this candidate.",
+      "Promotion requires human review and a separate Core-X registry/docs change.",
+    ],
+    evidence_summary: buildEvidenceSummary(knowledgeArtifact, snapshot),
+    duplicate_matches: [],
+    conflict_findings: [],
+    risk_findings: [],
+    review_status: "pending",
+    created_at: createdAt,
+    generated_by: GENERATED_BY,
+    tool: TOOL,
+  };
+
+  base.duplicate_matches = duplicateMatches(base, existingSkillIndex, existingCandidates);
+  base.conflict_findings = conflictFindings(base, knowledgeArtifact, existingSkillIndex);
+  base.risk_findings = riskFindings(base, knowledgeArtifact);
+
+  const checksumPayload = {
+    candidate_id: base.candidate_id,
+    suggested_skill_id: base.suggested_skill_id,
+    description: base.description,
+    source_repository: base.source_repository,
+    source_snapshot_identity: base.source_snapshot_identity,
+    provenance_references: base.provenance_references,
+    suggested_corex_lane: base.suggested_corex_lane,
+    suggested_scope: base.suggested_scope,
+    required_tools_services: base.required_tools_services,
+    license_status: base.license_status,
+    evidence_summary: base.evidence_summary,
+    duplicate_matches: base.duplicate_matches,
+    conflict_findings: base.conflict_findings,
+    risk_findings: base.risk_findings,
+  };
+  base.content_checksum = `sha256:${sha256(stableStringify(checksumPayload))}`;
+  base.draft_skill_md = draftSkillMarkdown(base);
+  return base;
+}
+
+export function validateSkillCandidate(candidate) {
+  const missing = [];
+  for (const field of [
+    "candidate_id",
+    "name",
+    "description",
+    "source_repository",
+    "source_snapshot_identity",
+    "provenance_references",
+    "suggested_corex_lane",
+    "suggested_scope",
+    "required_tools_services",
+    "license_status",
+    "evidence_summary",
+    "duplicate_matches",
+    "conflict_findings",
+    "risk_findings",
+    "review_status",
+    "content_checksum",
+  ]) {
+    if (candidate?.[field] === undefined || candidate?.[field] === null) missing.push(field);
+  }
+
+  const scanText = textForScanning(candidate || {});
+  const blockers = [
+    ...patternFindings(LOCAL_PATH_PATTERNS, scanText, "absolute_local_path"),
+    ...patternFindings(SECRET_PATTERNS, scanText, "secret_or_credential"),
+  ];
+  if (candidate?.review_status !== "pending") {
+    blockers.push({ kind: "review_gate", severity: "blocking", summary: "Skill candidates must start as pending." });
+  }
+  if (candidate?.source_repository?.private === true && candidate?.visibility === "public") {
+    blockers.push({ kind: "privacy", severity: "blocking", summary: "Private repository candidates cannot be public." });
+  }
+
+  return {
+    valid: missing.length === 0 && blockers.length === 0,
+    missing,
+    blockers,
+    warnings: toArray(candidate?.conflict_findings).filter((finding) => finding.severity !== "blocking"),
+  };
+}
+
+export function buildPromotionProposal(candidate, options = {}) {
+  const safeId = slug(candidate?.candidate_id || candidate?.suggested_skill_id || "unknown");
+  return {
+    id: `vega.capability-promotion:${safeId}`,
+    artifact_id: candidate.candidate_id,
+    target_kind: "skill",
+    target_path: `core-x/skills/${candidate.suggested_skill_id}/SKILL.md`,
+    rationale: `Promote ${candidate.name} after review because Vega detected reusable capability evidence from ${candidate.source_repository.nwo}.`,
+    expected_value: candidate.evidence_summary,
+    risk_level: candidate.conflict_findings.some((finding) => finding.severity === "blocking") ? "high" : "medium",
+    required_reviewers: ["core-x-maintainer", "skill-owner"],
+    promotion_status: "pending_review",
+    rollback_notes: "No registry mutation is performed by Vega. If promoted later, revert the separate Core-X registry/docs commit.",
+    provenance: {
+      source_refs: candidate.provenance_references,
+      evidence_refs: [candidate.source_snapshot_identity.artifact_ref].filter(Boolean),
+      derived_from: [candidate.candidate_id, candidate.source_snapshot_identity.snapshot_id].filter(Boolean),
+      review_artifact_ref: options.reviewArtifactRef || `data/review/skill-candidates/${slug(candidate.candidate_id)}.json`,
+    },
+    metadata: {
+      generated_by: GENERATED_BY,
+      created_at: options.createdAt || candidate.created_at || new Date().toISOString(),
+      review_status: "pending",
+      visibility: "internal",
+    },
+  };
+}
+
+async function writeCandidateArtifacts(outDir, candidates, options = {}) {
+  const candidateDir = path.join(outDir, "skill-candidates");
+  const proposalDir = path.join(outDir, "capability-promotions");
+  await fs.mkdir(candidateDir, { recursive: true });
+  await fs.mkdir(proposalDir, { recursive: true });
+
+  for (const candidate of candidates) {
+    const safeName = slug(candidate.candidate_id);
+    const candidateRef = path.join(candidateDir, `${safeName}.json`);
+    await fs.writeFile(candidateRef, `${JSON.stringify(candidate, null, 2)}\n`, "utf8");
+    const proposal = buildPromotionProposal(candidate, {
+      createdAt: options.createdAt,
+      reviewArtifactRef: path.relative(options.projectRoot || projectRoot, candidateRef),
+    });
+    await fs.writeFile(path.join(proposalDir, `${safeName}.json`), `${JSON.stringify(proposal, null, 2)}\n`, "utf8");
+
+    if (options.emitDraftFolders) {
+      const draftDir = path.join(outDir, "skill-drafts", safeName);
+      await fs.mkdir(path.join(draftDir, "references"), { recursive: true });
+      await fs.writeFile(path.join(draftDir, "SKILL.md"), candidate.draft_skill_md, "utf8");
+      await fs.writeFile(path.join(draftDir, "references", "SOURCELOG.md"), [
+        `# Source Log: ${candidate.name}`,
+        "",
+        `- Repository: ${candidate.source_repository.nwo}`,
+        `- Snapshot: ${candidate.source_snapshot_identity.snapshot_id}`,
+        ...candidate.provenance_references.map((ref) => `- ${ref}`),
+        "",
+      ].join("\n"), "utf8");
+      await fs.writeFile(path.join(draftDir, "references", "EVIDENCE.md"), [
+        `# Evidence: ${candidate.name}`,
+        "",
+        candidate.evidence_summary,
+        "",
+        "## Risks",
+        ...candidate.risk_findings.map((finding) => `- ${finding.severity}: ${finding.summary}`),
+        "",
+      ].join("\n"), "utf8");
+    }
+  }
+}
+
+export async function buildSkillCandidateIngestion(options = {}) {
+  const root = options.projectRoot || projectRoot;
+  const outDir = options.outDir || path.join(root, "data", "review");
+  const createdAt = options.createdAt || new Date().toISOString();
+  const corexRoot = options.corexRoot || detectCorexRoot(root);
+  const contractResult = await buildCorexContractArtifacts({
+    projectRoot: root,
+    outDir,
+    limit: options.limit,
+    all: options.all,
+    scope: options.scope,
+    dryRun: true,
+    createdAt,
+  });
+  const existingSkillIndex = await loadExistingSkillIndex(corexRoot);
+  const existingCandidates = await loadExistingCandidates(root, outDir);
+  const candidates = contractResult.artifacts.map((pair) => buildCandidate({
+    pair,
+    existingSkillIndex,
+    existingCandidates,
+    createdAt,
+  }));
+  const proposals = candidates.map((candidate) => buildPromotionProposal(candidate, { createdAt }));
+
+  return {
+    generated_by: GENERATED_BY,
+    created_at: createdAt,
+    dry_run: options.dryRun === true,
+    selected_count: candidates.length,
+    available_count: contractResult.available_count,
+    outputs: {
+      skill_candidates: path.relative(root, path.join(outDir, "skill-candidates")),
+      capability_promotions: path.relative(root, path.join(outDir, "capability-promotions")),
+      skill_drafts: path.relative(root, path.join(outDir, "skill-drafts")),
+    },
+    source_artifacts: contractResult.artifacts,
+    candidates,
+    proposals,
+    checks: {
+      corex_skill_index_available: existingSkillIndex.available,
+      existing_skill_count: existingSkillIndex.skillRecords.length,
+      existing_candidate_count: existingCandidates.length,
+    },
+  };
+}
+
+export async function listSkillCandidates(options = {}) {
+  const result = await buildSkillCandidateIngestion({ ...options, dryRun: true });
+  return {
+    count: result.candidates.length,
+    candidates: result.candidates,
+    checks: result.checks,
+  };
+}
+
+export async function getSkillCandidate(candidateId, options = {}) {
+  const result = await buildSkillCandidateIngestion({ ...options, dryRun: true, all: options.all ?? true, limit: options.limit ?? 250 });
+  return result.candidates.find((candidate) => candidate.candidate_id === candidateId || candidate.suggested_skill_id === candidateId) || null;
+}
+
+export async function proposeSkillPromotion(candidateId, options = {}) {
+  const candidate = await getSkillCandidate(candidateId, options);
+  if (!candidate) return null;
+  const validation = validateSkillCandidate(candidate);
+  const proposal = buildPromotionProposal(candidate, { createdAt: options.createdAt });
+
+  if (options.write === true) {
+    const root = options.projectRoot || projectRoot;
+    const outDir = options.outDir || path.join(root, "data", "review");
+    const proposalDir = path.join(outDir, "capability-promotions");
+    await fs.mkdir(proposalDir, { recursive: true });
+    await fs.writeFile(path.join(proposalDir, `${slug(candidate.candidate_id)}.json`), `${JSON.stringify(proposal, null, 2)}\n`, "utf8");
+  }
+
+  return { candidate, validation, proposal, wrote: options.write === true };
+}
+
+export async function runBuildSkillCandidates(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  const result = await buildSkillCandidateIngestion(options);
+
+  if (!options.dryRun) {
+    await writeCandidateArtifacts(options.outDir, result.candidates, {
+      projectRoot: options.projectRoot,
+      createdAt: result.created_at,
+      emitDraftFolders: options.emitDraftFolders,
+    });
+  }
+
+  const summary = {
+    generated_by: result.generated_by,
+    created_at: result.created_at,
+    dry_run: result.dry_run,
+    selected_count: result.selected_count,
+    available_count: result.available_count,
+    outputs: result.outputs,
+    checks: result.checks,
+    candidates: result.candidates.map((candidate) => ({
+      candidate_id: candidate.candidate_id,
+      suggested_skill_id: candidate.suggested_skill_id,
+      source_repository: candidate.source_repository.nwo,
+      suggested_corex_lane: candidate.suggested_corex_lane,
+      suggested_scope: candidate.suggested_scope,
+      license_status: candidate.license_status.status,
+      duplicate_matches: candidate.duplicate_matches.length,
+      conflict_findings: candidate.conflict_findings.length,
+      risk_findings: candidate.risk_findings.length,
+      review_status: candidate.review_status,
+      content_checksum: candidate.content_checksum,
+    })),
+  };
+  console.log(JSON.stringify(summary, null, 2));
+  return result;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runBuildSkillCandidates().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/src/mcp-server/index.js
+++ b/src/mcp-server/index.js
@@ -27,6 +27,12 @@ import {
   updateResearchQueue,
 } from "../server/house-model.js";
 import { executeVegaOcrTool, OCR_TOOL_DEFINITIONS } from "../server/ocr-tools.js";
+import {
+  getSkillCandidate,
+  listSkillCandidates,
+  proposeSkillPromotion,
+  validateSkillCandidate,
+} from "../../scripts/build-skill-candidates.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -527,6 +533,54 @@ class VegaLabServer {
           description: "Return local OpenResponses, dataset, and tool availability expectations for Vega Lab",
           inputSchema: { type: "object", properties: {} },
         },
+        {
+          name: "list_skill_candidates",
+          description: "Build and list deterministic review-gated skill candidates from Vega repo caches and review artifacts",
+          inputSchema: {
+            type: "object",
+            properties: {
+              limit: { type: "number", default: 10 },
+              scope: { type: "string", enum: ["mine", "starred", "all"], default: "all" },
+            },
+          },
+        },
+        {
+          name: "get_skill_candidate",
+          description: "Return one deterministic skill candidate by candidate_id or suggested_skill_id",
+          inputSchema: {
+            type: "object",
+            properties: {
+              candidate_id: { type: "string" },
+              limit: { type: "number", default: 250 },
+            },
+            required: ["candidate_id"],
+          },
+        },
+        {
+          name: "validate_skill_candidate",
+          description: "Validate one deterministic skill candidate for review-gate blockers",
+          inputSchema: {
+            type: "object",
+            properties: {
+              candidate_id: { type: "string" },
+              limit: { type: "number", default: 250 },
+            },
+            required: ["candidate_id"],
+          },
+        },
+        {
+          name: "propose_skill_promotion",
+          description: "Draft a pending Core-X capability-promotion proposal from a skill candidate without mutating registries",
+          inputSchema: {
+            type: "object",
+            properties: {
+              candidate_id: { type: "string" },
+              write: { type: "boolean", default: false },
+              limit: { type: "number", default: 250 },
+            },
+            required: ["candidate_id"],
+          },
+        },
         ...OCR_TOOL_DEFINITIONS,
       ],
     }));
@@ -590,6 +644,14 @@ class VegaLabServer {
             return await this.handleDraftActionItem(args);
           case "get_runtime_health":
             return this.handleGetRuntimeHealth();
+          case "list_skill_candidates":
+            return await this.handleListSkillCandidates(args);
+          case "get_skill_candidate":
+            return await this.handleGetSkillCandidate(args);
+          case "validate_skill_candidate":
+            return await this.handleValidateSkillCandidate(args);
+          case "propose_skill_promotion":
+            return await this.handleProposeSkillPromotion(args);
           case "inspect_model_zoo":
           case "ocr_health":
           case "inspect_image_with_ocr":
@@ -997,10 +1059,57 @@ class VegaLabServer {
         REPO_OPS_KITS_FILE,
       ],
       tools: {
-        total: 34,
+        total: 38,
         draftOnly: true,
       },
     });
+  }
+
+  async handleListSkillCandidates(args) {
+    const result = await listSkillCandidates({
+      projectRoot: HOUSE_ROOT,
+      limit: args.limit ?? 10,
+      scope: args.scope ?? "all",
+      dryRun: true,
+    });
+    return this.response(result);
+  }
+
+  async handleGetSkillCandidate(args) {
+    const candidate = await getSkillCandidate(args.candidate_id, {
+      projectRoot: HOUSE_ROOT,
+      limit: args.limit ?? 250,
+    });
+    if (!candidate) {
+      throw new Error("Skill candidate not found");
+    }
+    return this.response(candidate);
+  }
+
+  async handleValidateSkillCandidate(args) {
+    const candidate = await getSkillCandidate(args.candidate_id, {
+      projectRoot: HOUSE_ROOT,
+      limit: args.limit ?? 250,
+    });
+    if (!candidate) {
+      throw new Error("Skill candidate not found");
+    }
+    return this.response({
+      candidate_id: candidate.candidate_id,
+      validation: validateSkillCandidate(candidate),
+    });
+  }
+
+  async handleProposeSkillPromotion(args) {
+    const result = await proposeSkillPromotion(args.candidate_id, {
+      projectRoot: HOUSE_ROOT,
+      limit: args.limit ?? 250,
+      write: args.write === true,
+    });
+    if (!result) {
+      throw new Error("Skill candidate not found");
+    }
+    return this.response(result);
   }
 
   async run() {

--- a/tests/test-mcp-server.js
+++ b/tests/test-mcp-server.js
@@ -118,6 +118,10 @@ async function main() {
       "extract_repo_visual_evidence",
       "extract_skill_evidence_from_pdf",
       "generate_skill_candidate_from_ocr_evidence",
+      "list_skill_candidates",
+      "get_skill_candidate",
+      "validate_skill_candidate",
+      "propose_skill_promotion",
     ].forEach((toolName) => {
       assert.ok(toolNames.has(toolName), `Expected MCP tool to exist: ${toolName}`);
     });

--- a/tests/test-skill-candidate-ingestion.js
+++ b/tests/test-skill-candidate-ingestion.js
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  buildSkillCandidateIngestion,
+  getSkillCandidate,
+  listSkillCandidates,
+  proposeSkillPromotion,
+  runBuildSkillCandidates,
+  validateSkillCandidate,
+} from "../scripts/build-skill-candidates.js";
+
+async function writeJson(filePath, data) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+}
+
+async function exists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  const originalCwd = process.cwd();
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "vega-skill-candidate-"));
+  const corexRoot = path.join(root, "core-x");
+  const projectRoot = path.join(root, "vega-lab");
+
+  const repo = {
+    name: "agent-toolkit",
+    author: "example",
+    description: "A deterministic agent workflow toolkit.",
+    url: "https://github.com/example/agent-toolkit",
+    stars: 700,
+    forks: 40,
+    primary_language: "TypeScript",
+    topics: ["agent", "workflow", "mcp"],
+    license: "MIT",
+  };
+
+  try {
+    await writeJson(path.join(projectRoot, "data", "data.json"), [repo]);
+    await writeJson(path.join(projectRoot, "data", "my-repos.json"), []);
+    await writeJson(path.join(projectRoot, "data", "repo-signals.json"), [{
+      nwo: "example/agent-toolkit",
+      description: repo.description,
+      adoptionScore: 88,
+      adoptionKind: "tool",
+      capabilities: ["agent-workflows", "developer-tooling"],
+      houseSkills: ["skill-extraction"],
+    }]);
+    await writeJson(path.join(projectRoot, "data", "skill-extractions.json"), [{
+      nwo: "example/agent-toolkit",
+      summary: "Reusable MCP agent workflow primitives.",
+      capabilities: ["agent-workflows"],
+      houseSkills: ["skill-extraction"],
+      flows: ["research-queue-flow"],
+      adoptionKind: "tool",
+    }]);
+
+    await fs.mkdir(path.join(corexRoot, "skills", "vega-example-agent-toolkit"), { recursive: true });
+    await fs.writeFile(
+      path.join(corexRoot, "skills", "vega-example-agent-toolkit", "SKILL.md"),
+      "# Example Agent Toolkit\n\nExisting reviewed skill.\n",
+      "utf8",
+    );
+
+    process.chdir(projectRoot);
+    const outDir = path.join(projectRoot, "data", "review");
+    const result = await buildSkillCandidateIngestion({
+      projectRoot,
+      corexRoot,
+      outDir,
+      dryRun: true,
+      limit: 1,
+      createdAt: "2026-06-13T00:00:00.000Z",
+    });
+
+    assert.equal(result.selected_count, 1);
+    assert.equal(result.candidates.length, 1);
+    assert.equal(result.proposals.length, 1);
+    assert.equal(result.checks.corex_skill_index_available, true);
+
+    const candidate = result.candidates[0];
+    assert.equal(candidate.candidate_id, "vega.skill-candidate:example-agent-toolkit");
+    assert.equal(candidate.review_status, "pending");
+    assert.equal(candidate.source_repository.nwo, "example/agent-toolkit");
+    assert.equal(candidate.suggested_corex_lane, "agent-workflows");
+    assert.equal(candidate.license_status.status, "compatible");
+    assert.ok(candidate.duplicate_matches.some((match) => match.kind === "duplicate_id"));
+    assert.ok(candidate.content_checksum.startsWith("sha256:"));
+    assert.ok(!JSON.stringify(candidate).includes("README body"));
+    assert.ok(!JSON.stringify(candidate).includes("/Users/"));
+
+    const validation = validateSkillCandidate(candidate);
+    assert.equal(validation.valid, true);
+
+    const invalid = validateSkillCandidate({
+      ...candidate,
+      description: "bad /Users/" + "davidcaballero/private-path",
+    });
+    assert.equal(invalid.valid, false);
+    assert.ok(invalid.blockers.some((blocker) => blocker.kind === "absolute_local_path"));
+
+    const listed = await listSkillCandidates({
+      projectRoot,
+      corexRoot,
+      outDir,
+      limit: 1,
+      createdAt: "2026-06-13T00:00:00.000Z",
+    });
+    assert.equal(listed.count, 1);
+
+    const fetched = await getSkillCandidate(candidate.candidate_id, {
+      projectRoot,
+      corexRoot,
+      outDir,
+      limit: 1,
+      createdAt: "2026-06-13T00:00:00.000Z",
+    });
+    assert.equal(fetched.candidate_id, candidate.candidate_id);
+
+    const promotion = await proposeSkillPromotion(candidate.candidate_id, {
+      projectRoot,
+      corexRoot,
+      outDir,
+      limit: 1,
+      createdAt: "2026-06-13T00:00:00.000Z",
+    });
+    assert.equal(promotion.proposal.target_kind, "skill");
+    assert.equal(promotion.proposal.promotion_status, "pending_review");
+    assert.equal(promotion.wrote, false);
+
+    await runBuildSkillCandidates([
+      "--limit=1",
+      `--project-root=${projectRoot}`,
+      `--corex-root=${corexRoot}`,
+      `--out-dir=${outDir}`,
+      "--created-at=2026-06-13T00:00:00.000Z",
+    ]);
+    assert.ok(await exists(path.join(outDir, "skill-candidates", "vega-skill-candidate-example-agent-toolkit.json")));
+    assert.ok(await exists(path.join(outDir, "capability-promotions", "vega-skill-candidate-example-agent-toolkit.json")));
+  } finally {
+    process.chdir(originalCwd);
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error("Skill candidate ingestion test failed");
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds a deterministic skill-candidate compiler from existing Vega repo/star caches and Core-X contract artifacts.
- Adds review-gated MCP tools for listing, fetching, validating, and proposing skill promotions without mutating Core-X registries.
- Adds targeted tests and package scripts for dry-run ingestion and candidate validation.

## Verification
- npm run build:skill-candidates -- --dry-run --limit=2
- npm run test:skill-candidate-ingestion
- npm run test:corex-contract-export
- npm run test:mcp
- node --check scripts/build-skill-candidates.js
- node --check tests/test-skill-candidate-ingestion.js
- git diff --check

## Safety
- No generated review artifacts committed.
- No data/public JSON committed.
- No registry mutation or automatic promotion.
