### PR TITLE
feat(vega): adopt Core-X skill candidate contract v1

### DIFF
--- a/contracts/corex/README.md
+++ b/contracts/corex/README.md
@@ -1,0 +1,17 @@
+# Core-X Skill Contract Snapshots
+
+Generated from Core-X. Do not hand-edit these files.
+
+Refresh with:
+
+```bash
+corex vega contracts export --target contracts/corex
+```
+
+Check for drift with:
+
+```bash
+corex vega contracts export --target contracts/corex --check
+```
+
+Core-X owns the canonical schemas. Vega consumes these deterministic snapshots and validates emitted skill candidates and review envelopes against them with Ajv 2020.

--- a/contracts/corex/corex.vega-skill-candidate.v1.schema.json
+++ b/contracts/corex/corex.vega-skill-candidate.v1.schema.json
@@ -1,0 +1,274 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:corex:schema:corex.vega-skill-candidate.v1",
+  "title": "Core-X Vega Skill Candidate v1",
+  "description": "Canonical Core-X-owned contract for Vega-produced skill promotion candidates.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "candidate_id",
+    "suggested_skill_id",
+    "name",
+    "description",
+    "source_repository",
+    "source_snapshot_identity",
+    "provenance_references",
+    "suggested_corex_lane",
+    "suggested_scope",
+    "required_tools_services",
+    "license_status",
+    "evidence_summary",
+    "conflict_findings",
+    "risk_findings",
+    "review_status",
+    "content_checksum"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "corex.vega-skill-candidate.v1"
+    },
+    "candidate_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "suggested_skill_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_repository": {
+      "type": "object",
+      "required": ["nwo", "uri"],
+      "properties": {
+        "nwo": {
+          "type": "string",
+          "minLength": 1
+        },
+        "uri": {
+          "type": "string",
+          "minLength": 1
+        },
+        "scope": {
+          "type": "string"
+        },
+        "private": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "source_snapshot_identity": {
+      "type": "object",
+      "required": ["snapshot_id", "source_ref", "artifact_ref"],
+      "properties": {
+        "snapshot_id": {
+          "type": ["string", "null"]
+        },
+        "source_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "artifact_ref": {
+          "type": ["string", "null"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "provenance_references": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "suggested_corex_lane": {
+      "type": "string",
+      "enum": [
+        "visual-runtime",
+        "agent-workflows",
+        "research-intelligence",
+        "frontend-ui",
+        "developer-tooling",
+        "core-capability"
+      ]
+    },
+    "suggested_scope": {
+      "type": "string",
+      "enum": ["house-local", "shared"]
+    },
+    "required_tools_services": {
+      "type": "object",
+      "required": ["tools", "services"],
+      "properties": {
+        "tools": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "services": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "license_status": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "compatible",
+            "incompatible",
+            "unknown",
+            "restricted",
+            "review-required"
+          ]
+        },
+        "identifier": {
+          "type": ["string", "null"]
+        },
+        "source": {
+          "type": ["string", "null"]
+        },
+        "notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "compatibility_assumptions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "evidence_summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "duplicate_matches": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/duplicate_match"
+      }
+    },
+    "conflict_findings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/finding"
+      }
+    },
+    "risk_findings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/finding"
+      }
+    },
+    "review_status": {
+      "type": "string",
+      "enum": ["pending", "approved", "rejected"]
+    },
+    "created_at": {
+      "type": "string"
+    },
+    "generated_by": {
+      "type": "string"
+    },
+    "tool": {
+      "type": "object",
+      "properties": {
+        "tool_id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "content_checksum": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "draft_skill_md": {
+      "type": "string"
+    }
+  },
+  "$defs": {
+    "duplicate_match": {
+      "type": "object",
+      "required": ["kind", "target", "confidence", "source"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target": {
+          "type": "string",
+          "minLength": 1
+        },
+        "label": {
+          "type": "string"
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "finding": {
+      "type": "object",
+      "required": ["kind", "severity", "summary"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["info", "warning", "blocking"]
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/corex/corex.vega-skill-review.v1.schema.json
+++ b/contracts/corex/corex.vega-skill-review.v1.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:corex:schema:corex.vega-skill-review.v1",
+  "title": "Core-X Vega Skill Review v1",
+  "description": "Immutable human-review envelope for a Vega skill candidate.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "review_id",
+    "candidate_id",
+    "candidate_checksum",
+    "status",
+    "reviewer",
+    "reviewed_at"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "corex.vega-skill-review.v1"
+    },
+    "review_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "candidate_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "candidate_checksum": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["approved", "rejected", "changes-requested"]
+    },
+    "reviewer": {
+      "type": "object",
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "display_name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "reviewed_at": {
+      "type": "string",
+      "minLength": 1
+    },
+    "notes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "resolved_findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["kind", "summary"],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "minLength": 1
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1
+          },
+          "source_refs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/corex/manifest.json
+++ b/contracts/corex/manifest.json
@@ -1,0 +1,17 @@
+{
+  "contract_set": "corex.vega-skill-contracts",
+  "generated_from": "core-x",
+  "schemas": [
+    {
+      "name": "corex.vega-skill-candidate.v1.schema.json",
+      "schema_version": "corex.vega-skill-candidate.v1",
+      "sha256": "sha256:50678acd7ee571fbeb6ff1882fc42b3e47e00ba5a66d9477fb46746a0609feac"
+    },
+    {
+      "name": "corex.vega-skill-review.v1.schema.json",
+      "schema_version": "corex.vega-skill-review.v1",
+      "sha256": "sha256:53de1edec53f3e59c511b65e64e11916164372a7962feba6119cf6cd2e330e5c"
+    }
+  ],
+  "version": "1"
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:data": "node tests/run-tests.js",
     "test:mcp": "node tests/test-mcp-server.js && node tests/test-ocr-skill-candidate.js",
     "test:corex-contract-export": "node tests/test-corex-contract-export.js",
+    "test:corex-contract-snapshots": "node tests/test-corex-contract-snapshots.js",
     "test:skill-candidate-ingestion": "node tests/test-skill-candidate-ingestion.js",
     "test": "npm run lint && npm run test:data && npm run test:mcp"
   },
@@ -51,6 +52,7 @@
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "@vitejs/plugin-react": "^4.2.1",
+    "ajv": "^8.20.0",
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.2.1
         version: 4.7.0(vite@7.3.1)
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -810,8 +813,8 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -2122,8 +2125,8 @@ snapshots:
   '@modelcontextprotocol/sdk@1.25.3(hono@4.11.7)(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.7)
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
@@ -2569,9 +2572,9 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  ajv-formats@3.0.1(ajv@8.17.1):
+  ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.20.0
 
   ajv@6.12.6:
     dependencies:
@@ -2580,7 +2583,7 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ajv@8.17.1:
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0

--- a/scripts/build-skill-candidates.js
+++ b/scripts/build-skill-candidates.js
@@ -6,6 +6,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import Ajv2020 from "ajv/dist/2020.js";
 import { buildCorexContractArtifacts } from "./export-corex-contracts.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -13,11 +14,33 @@ const __dirname = path.dirname(__filename);
 const projectRoot = path.resolve(__dirname, "..");
 
 const GENERATED_BY = "vega-lab:build-skill-candidates";
+const CANDIDATE_SCHEMA_VERSION = "corex.vega-skill-candidate.v1";
+const REVIEW_SCHEMA_VERSION = "corex.vega-skill-review.v1";
+const CONTRACTS_ROOT = path.join(projectRoot, "contracts", "corex");
 const TOOL = {
   tool_id: "vega.build_skill_candidates",
   name: "Vega Skill Candidate Ingestion",
   version: "0.1.0",
 };
+const CANDIDATE_CHECKSUM_FIELDS = [
+  "schema_version",
+  "candidate_id",
+  "suggested_skill_id",
+  "name",
+  "description",
+  "source_repository",
+  "source_snapshot_identity",
+  "provenance_references",
+  "suggested_corex_lane",
+  "suggested_scope",
+  "required_tools_services",
+  "license_status",
+  "compatibility_assumptions",
+  "evidence_summary",
+  "duplicate_matches",
+  "conflict_findings",
+  "risk_findings",
+];
 
 const SECRET_PATTERNS = [
   new RegExp(["BEGIN", "[A-Z ]*", "PRIVATE", "KEY"].join(" "), "i"),
@@ -96,6 +119,44 @@ function stableStringify(value) {
     return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(",")}}`;
   }
   return JSON.stringify(value);
+}
+
+function readContractSchema(name) {
+  return JSON.parse(fsSync.readFileSync(path.join(CONTRACTS_ROOT, name), "utf8"));
+}
+
+const ajv = new Ajv2020({
+  allErrors: true,
+  coerceTypes: false,
+  strict: true,
+  useDefaults: false,
+});
+const candidateSchema = readContractSchema("corex.vega-skill-candidate.v1.schema.json");
+const reviewSchema = readContractSchema("corex.vega-skill-review.v1.schema.json");
+const validateCandidateSchema = ajv.compile(candidateSchema);
+const validateReviewSchema = ajv.compile(reviewSchema);
+
+function schemaErrors(validator) {
+  return (validator.errors || []).map((error) => {
+    const pathText = error.instancePath ? `${error.instancePath} ` : "";
+    return `${pathText}${error.message}`;
+  });
+}
+
+export function candidateContentChecksum(candidate) {
+  const payload = {};
+  for (const field of CANDIDATE_CHECKSUM_FIELDS) {
+    payload[field] = Object.hasOwn(candidate, field) ? candidate[field] : null;
+  }
+  return `sha256:${sha256(stableStringify(payload))}`;
+}
+
+export function validateSkillReview(review) {
+  const valid = validateReviewSchema(review);
+  return {
+    valid: valid === true,
+    schema_errors: valid ? [] : schemaErrors(validateReviewSchema),
+  };
 }
 
 function repoNwoFromArtifact(pair) {
@@ -297,18 +358,43 @@ function inferRequiredToolsAndServices(lane, knowledgeArtifact) {
 function licenseStatus(license) {
   const value = String(license || "").trim();
   if (!value || /^none$/i.test(value)) {
-    return { status: "unknown", review_required: true, notes: "Missing or unspecified license; requires manual review before adoption." };
+    return {
+      status: "unknown",
+      identifier: null,
+      source: "repository-metadata",
+      notes: ["Missing or unspecified license; requires manual review before adoption."],
+    };
   }
   if (/agpl/i.test(value)) {
-    return { status: "incompatible", review_required: true, notes: "AGPL-style license detected; promotion may conflict with distribution goals." };
+    return {
+      status: "incompatible",
+      identifier: value,
+      source: "repository-metadata",
+      notes: ["AGPL-style license detected; promotion may conflict with distribution goals."],
+    };
   }
   if (/(gpl|lgpl)/i.test(value)) {
-    return { status: "restricted", review_required: true, notes: "GPL-family license detected; adoption scope must be reviewed." };
+    return {
+      status: "restricted",
+      identifier: value,
+      source: "repository-metadata",
+      notes: ["GPL-family license detected; adoption scope must be reviewed."],
+    };
   }
   if (/(mit|apache|bsd|isc|mpl|unlicense|cc0)/i.test(value)) {
-    return { status: "compatible", review_required: false, notes: `License appears adoption-friendly: ${value}.` };
+    return {
+      status: "compatible",
+      identifier: value,
+      source: "repository-metadata",
+      notes: [`License appears adoption-friendly: ${value}.`],
+    };
   }
-  return { status: "review", review_required: true, notes: `License requires manual compatibility review: ${value}.` };
+  return {
+    status: "review-required",
+    identifier: value,
+    source: "repository-metadata",
+    notes: [`License requires manual compatibility review: ${value}.`],
+  };
 }
 
 function textForScanning(candidateInput) {
@@ -403,11 +489,11 @@ function conflictFindings(candidate, knowledgeArtifact, existingSkillIndex) {
     });
   }
 
-  if (candidate.license_status.status === "unknown" || candidate.license_status.status === "incompatible") {
+  if (["unknown", "incompatible", "restricted", "review-required"].includes(candidate.license_status.status)) {
     findings.push({
       kind: "license",
-      severity: candidate.license_status.status === "incompatible" ? "blocking" : "warning",
-      summary: candidate.license_status.notes,
+      severity: ["incompatible", "restricted"].includes(candidate.license_status.status) ? "blocking" : "warning",
+      summary: toArray(candidate.license_status.notes).join(" ") || "License requires review.",
       source_refs: candidate.provenance_references,
     });
   }
@@ -505,6 +591,7 @@ function buildCandidate({ pair, existingSkillIndex, existingCandidates, createdA
   ]);
 
   const base = {
+    schema_version: CANDIDATE_SCHEMA_VERSION,
     candidate_id: `vega.skill-candidate:${safeRepo}`,
     suggested_skill_id: suggestedSkillId,
     name: `${snapshot?.metadata?.name || nwo} Core-X Skill Candidate`,
@@ -543,56 +630,23 @@ function buildCandidate({ pair, existingSkillIndex, existingCandidates, createdA
   base.duplicate_matches = duplicateMatches(base, existingSkillIndex, existingCandidates);
   base.conflict_findings = conflictFindings(base, knowledgeArtifact, existingSkillIndex);
   base.risk_findings = riskFindings(base, knowledgeArtifact);
-
-  const checksumPayload = {
-    candidate_id: base.candidate_id,
-    suggested_skill_id: base.suggested_skill_id,
-    description: base.description,
-    source_repository: base.source_repository,
-    source_snapshot_identity: base.source_snapshot_identity,
-    provenance_references: base.provenance_references,
-    suggested_corex_lane: base.suggested_corex_lane,
-    suggested_scope: base.suggested_scope,
-    required_tools_services: base.required_tools_services,
-    license_status: base.license_status,
-    evidence_summary: base.evidence_summary,
-    duplicate_matches: base.duplicate_matches,
-    conflict_findings: base.conflict_findings,
-    risk_findings: base.risk_findings,
-  };
-  base.content_checksum = `sha256:${sha256(stableStringify(checksumPayload))}`;
+  base.content_checksum = candidateContentChecksum(base);
   base.draft_skill_md = draftSkillMarkdown(base);
   return base;
 }
 
 export function validateSkillCandidate(candidate) {
-  const missing = [];
-  for (const field of [
-    "candidate_id",
-    "name",
-    "description",
-    "source_repository",
-    "source_snapshot_identity",
-    "provenance_references",
-    "suggested_corex_lane",
-    "suggested_scope",
-    "required_tools_services",
-    "license_status",
-    "evidence_summary",
-    "duplicate_matches",
-    "conflict_findings",
-    "risk_findings",
-    "review_status",
-    "content_checksum",
-  ]) {
-    if (candidate?.[field] === undefined || candidate?.[field] === null) missing.push(field);
-  }
-
+  const schemaValid = validateCandidateSchema(candidate);
   const scanText = textForScanning(candidate || {});
   const blockers = [
     ...patternFindings(LOCAL_PATH_PATTERNS, scanText, "absolute_local_path"),
     ...patternFindings(SECRET_PATTERNS, scanText, "secret_or_credential"),
   ];
+  const computedChecksum = candidate ? candidateContentChecksum(candidate) : "";
+  const checksumOk = candidate?.content_checksum === computedChecksum;
+  if (!checksumOk) {
+    blockers.push({ kind: "checksum", severity: "blocking", summary: "Candidate checksum does not match canonical content." });
+  }
   if (candidate?.review_status !== "pending") {
     blockers.push({ kind: "review_gate", severity: "blocking", summary: "Skill candidates must start as pending." });
   }
@@ -601,15 +655,51 @@ export function validateSkillCandidate(candidate) {
   }
 
   return {
-    valid: missing.length === 0 && blockers.length === 0,
-    missing,
+    valid: schemaValid === true && blockers.length === 0,
+    schema_errors: schemaValid ? [] : schemaErrors(validateCandidateSchema),
+    missing: schemaErrors(validateCandidateSchema).filter((error) => /required property/.test(error)),
     blockers,
+    checksum_ok: checksumOk,
+    computed_checksum: computedChecksum,
     warnings: toArray(candidate?.conflict_findings).filter((finding) => finding.severity !== "blocking"),
+  };
+}
+
+export function buildReviewEnvelope(candidate, options = {}) {
+  const reviewer = options.reviewer || {};
+  return {
+    schema_version: REVIEW_SCHEMA_VERSION,
+    review_id: options.reviewId || `review-${slug(candidate?.candidate_id || candidate?.suggested_skill_id || "unknown")}`,
+    candidate_id: candidate.candidate_id,
+    candidate_checksum: candidate.content_checksum,
+    status: options.status || "approved",
+    reviewer: {
+      id: reviewer.id || options.reviewerId || "compat-test@local",
+      ...(reviewer.display_name || options.reviewerDisplayName
+        ? { display_name: reviewer.display_name || options.reviewerDisplayName }
+        : {}),
+    },
+    reviewed_at: options.reviewedAt || new Date().toISOString(),
+    notes: toArray(options.notes),
+    resolved_findings: toArray(options.resolvedFindings),
+  };
+}
+
+export function applyReviewEnvelope(candidate, review) {
+  const status = review?.status === "approved"
+    ? "approved"
+    : review?.status === "rejected"
+      ? "rejected"
+      : "pending";
+  return {
+    ...candidate,
+    review_status: status,
   };
 }
 
 export function buildPromotionProposal(candidate, options = {}) {
   const safeId = slug(candidate?.candidate_id || candidate?.suggested_skill_id || "unknown");
+  const review = options.review || null;
   return {
     id: `vega.capability-promotion:${safeId}`,
     artifact_id: candidate.candidate_id,
@@ -619,18 +709,21 @@ export function buildPromotionProposal(candidate, options = {}) {
     expected_value: candidate.evidence_summary,
     risk_level: candidate.conflict_findings.some((finding) => finding.severity === "blocking") ? "high" : "medium",
     required_reviewers: ["core-x-maintainer", "skill-owner"],
-    promotion_status: "pending_review",
+    promotion_status: options.promotionStatus || "pending_review",
     rollback_notes: "No registry mutation is performed by Vega. If promoted later, revert the separate Core-X registry/docs commit.",
     provenance: {
       source_refs: candidate.provenance_references,
       evidence_refs: [candidate.source_snapshot_identity.artifact_ref].filter(Boolean),
       derived_from: [candidate.candidate_id, candidate.source_snapshot_identity.snapshot_id].filter(Boolean),
-      review_artifact_ref: options.reviewArtifactRef || `data/review/skill-candidates/${slug(candidate.candidate_id)}.json`,
+      review_artifact_ref: options.reviewArtifactRef || review?.review_id || `data/review/skill-candidates/${slug(candidate.candidate_id)}.json`,
     },
     metadata: {
       generated_by: GENERATED_BY,
       created_at: options.createdAt || candidate.created_at || new Date().toISOString(),
-      review_status: "pending",
+      candidate_id: candidate.candidate_id,
+      candidate_checksum: candidate.content_checksum,
+      ...(review?.review_id ? { review_id: review.review_id } : {}),
+      review_status: review?.status || "pending",
       visibility: "internal",
     },
   };
@@ -741,7 +834,11 @@ export async function proposeSkillPromotion(candidateId, options = {}) {
   const candidate = await getSkillCandidate(candidateId, options);
   if (!candidate) return null;
   const validation = validateSkillCandidate(candidate);
-  const proposal = buildPromotionProposal(candidate, { createdAt: options.createdAt });
+  const proposal = buildPromotionProposal(candidate, {
+    createdAt: options.createdAt,
+    review: options.review,
+    promotionStatus: options.promotionStatus,
+  });
 
   if (options.write === true) {
     const root = options.projectRoot || projectRoot;

--- a/tests/test-corex-contract-snapshots.js
+++ b/tests/test-corex-contract-snapshots.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import Ajv2020 from "ajv/dist/2020.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const projectRoot = path.resolve(path.dirname(__filename), "..");
+const contractsRoot = path.join(projectRoot, "contracts", "corex");
+
+function sha256Bytes(value) {
+  return `sha256:${crypto.createHash("sha256").update(value).digest("hex")}`;
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await fs.readFile(filePath, "utf8"));
+}
+
+async function main() {
+  const expected = [
+    "corex.vega-skill-candidate.v1.schema.json",
+    "corex.vega-skill-review.v1.schema.json",
+    "manifest.json",
+    "README.md",
+  ];
+
+  const entries = new Set(await fs.readdir(contractsRoot));
+  for (const name of expected) {
+    assert.ok(entries.has(name), `Missing Core-X contract snapshot: ${name}`);
+  }
+
+  const manifest = await readJson(path.join(contractsRoot, "manifest.json"));
+  assert.equal(manifest.contract_set, "corex.vega-skill-contracts");
+  assert.equal(manifest.version, "1");
+  assert.equal(manifest.generated_from, "core-x");
+  assert.ok(!JSON.stringify(manifest).includes("/Users/"));
+  assert.ok(!JSON.stringify(manifest).includes("/tmp/"));
+  assert.ok(!JSON.stringify(manifest).includes("feat/"));
+
+  for (const schema of manifest.schemas) {
+    const bytes = await fs.readFile(path.join(contractsRoot, schema.name));
+    assert.equal(sha256Bytes(bytes), schema.sha256, `Checksum mismatch for ${schema.name}`);
+  }
+
+  const candidateSchema = await readJson(path.join(contractsRoot, "corex.vega-skill-candidate.v1.schema.json"));
+  const reviewSchema = await readJson(path.join(contractsRoot, "corex.vega-skill-review.v1.schema.json"));
+  assert.equal(candidateSchema.properties.schema_version.const, "corex.vega-skill-candidate.v1");
+  assert.equal(reviewSchema.properties.schema_version.const, "corex.vega-skill-review.v1");
+
+  const ajv = new Ajv2020({
+    allErrors: true,
+    coerceTypes: false,
+    strict: true,
+    useDefaults: false,
+  });
+  ajv.compile(candidateSchema);
+  ajv.compile(reviewSchema);
+}
+
+main().catch((error) => {
+  console.error("Core-X contract snapshot test failed");
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/test-mcp-server.js
+++ b/tests/test-mcp-server.js
@@ -126,6 +126,30 @@ async function main() {
       assert.ok(toolNames.has(toolName), `Expected MCP tool to exist: ${toolName}`);
     });
 
+    const skillCandidatesResult = parseTextPayload(await client.callTool({
+      name: "list_skill_candidates",
+      arguments: { limit: 1, scope: "all" },
+    }));
+    assert.ok(skillCandidatesResult.count >= 1, "Skill candidate listing should return at least one candidate");
+    const skillCandidate = skillCandidatesResult.candidates[0];
+    assert.equal(skillCandidate.schema_version, "corex.vega-skill-candidate.v1", "MCP candidate should use canonical v1 schema");
+    assert.ok(skillCandidate.content_checksum.startsWith("sha256:"), "MCP candidate should expose a content checksum");
+
+    const skillValidationResult = parseTextPayload(await client.callTool({
+      name: "validate_skill_candidate",
+      arguments: { candidate_id: skillCandidate.candidate_id, limit: 1 },
+    }));
+    assert.equal(skillValidationResult.validation.valid, true, "MCP candidate validation should pass");
+    assert.equal(skillValidationResult.validation.checksum_ok, true, "MCP candidate checksum should match canonical content");
+
+    const skillProposalResult = parseTextPayload(await client.callTool({
+      name: "propose_skill_promotion",
+      arguments: { candidate_id: skillCandidate.candidate_id, limit: 1 },
+    }));
+    assert.equal(skillProposalResult.proposal.metadata.candidate_id, skillCandidate.candidate_id);
+    assert.equal(skillProposalResult.proposal.metadata.candidate_checksum, skillCandidate.content_checksum);
+    assert.equal(skillProposalResult.wrote, false, "MCP proposal should not write unless explicitly requested");
+
     const runtimeHealth = parseTextPayload(await client.callTool({
       name: "get_runtime_health",
       arguments: {},

--- a/tests/test-skill-candidate-ingestion.js
+++ b/tests/test-skill-candidate-ingestion.js
@@ -6,11 +6,15 @@ import os from "node:os";
 import path from "node:path";
 
 import {
+  applyReviewEnvelope,
+  buildReviewEnvelope,
   buildSkillCandidateIngestion,
+  candidateContentChecksum,
   getSkillCandidate,
   listSkillCandidates,
   proposeSkillPromotion,
   runBuildSkillCandidates,
+  validateSkillReview,
   validateSkillCandidate,
 } from "../scripts/build-skill-candidates.js";
 
@@ -90,18 +94,22 @@ async function main() {
     assert.equal(result.checks.corex_skill_index_available, true);
 
     const candidate = result.candidates[0];
+    assert.equal(candidate.schema_version, "corex.vega-skill-candidate.v1");
     assert.equal(candidate.candidate_id, "vega.skill-candidate:example-agent-toolkit");
     assert.equal(candidate.review_status, "pending");
     assert.equal(candidate.source_repository.nwo, "example/agent-toolkit");
     assert.equal(candidate.suggested_corex_lane, "agent-workflows");
     assert.equal(candidate.license_status.status, "compatible");
+    assert.deepEqual(Object.keys(candidate.required_tools_services).sort(), ["services", "tools"]);
     assert.ok(candidate.duplicate_matches.some((match) => match.kind === "duplicate_id"));
     assert.ok(candidate.content_checksum.startsWith("sha256:"));
+    assert.equal(candidate.content_checksum, candidateContentChecksum(candidate));
     assert.ok(!JSON.stringify(candidate).includes("README body"));
     assert.ok(!JSON.stringify(candidate).includes("/Users/"));
 
     const validation = validateSkillCandidate(candidate);
     assert.equal(validation.valid, true);
+    assert.equal(validation.checksum_ok, true);
 
     const invalid = validateSkillCandidate({
       ...candidate,
@@ -137,7 +145,32 @@ async function main() {
     });
     assert.equal(promotion.proposal.target_kind, "skill");
     assert.equal(promotion.proposal.promotion_status, "pending_review");
+    assert.equal(promotion.proposal.metadata.candidate_id, candidate.candidate_id);
+    assert.equal(promotion.proposal.metadata.candidate_checksum, candidate.content_checksum);
     assert.equal(promotion.wrote, false);
+
+    const review = buildReviewEnvelope(candidate, {
+      reviewId: "review-vega-example-agent-toolkit",
+      reviewerId: "compat-test@local",
+      reviewedAt: "2026-06-13T00:10:00.000Z",
+      notes: ["Test approval."],
+    });
+    assert.equal(validateSkillReview(review).valid, true);
+    assert.equal(review.candidate_id, candidate.candidate_id);
+    assert.equal(review.candidate_checksum, candidate.content_checksum);
+    const approvedCandidate = applyReviewEnvelope(candidate, review);
+    assert.equal(approvedCandidate.review_status, "approved");
+    assert.equal(approvedCandidate.content_checksum, candidate.content_checksum);
+
+    const approvedProposal = await proposeSkillPromotion(candidate.candidate_id, {
+      projectRoot,
+      corexRoot,
+      outDir,
+      limit: 1,
+      createdAt: "2026-06-13T00:00:00.000Z",
+      review,
+    });
+    assert.equal(approvedProposal.proposal.metadata.review_id, review.review_id);
 
     await runBuildSkillCandidates([
       "--limit=1",


### PR DESCRIPTION
## Summary\n- Add generated Core-X contract snapshots under contracts/corex\n- Emit canonical v1 skill candidates and review envelopes\n- Validate candidates/reviews with Ajv 2020 without coercion/default insertion\n- Reference candidate checksum and review ID in promotion proposals\n\n## Verification\n- node tests/test-corex-contract-export.js\n- node tests/test-corex-contract-snapshots.js\n- node tests/test-skill-candidate-ingestion.js\n- node tests/test-ocr-skill-candidate.js\n- node tests/test-mcp-server.js\n- pnpm exec eslint scripts/build-skill-candidates.js tests/test-skill-candidate-ingestion.js tests/test-corex-contract-snapshots.js tests/test-mcp-server.js