### PR TITLE
feat(vega): resolve immutable source snapshots for skill candidates

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build:data": "node scripts/generator.js",
     "sync:mine": "node scripts/my-repos.js",
     "sync:model-zoo": "node scripts/model-zoo-snapshot.js",
+    "resolve:source-snapshots": "node scripts/source-snapshot-resolver.js",
     "export:corex-contracts": "node scripts/export-corex-contracts.js",
     "build:skill-candidates": "node scripts/build-skill-candidates.js",
     "generate:stats": "node src/analytics/statistics.js",
@@ -24,6 +25,7 @@
     "test:mcp": "node tests/test-mcp-server.js && node tests/test-ocr-skill-candidate.js",
     "test:corex-contract-export": "node tests/test-corex-contract-export.js",
     "test:corex-contract-snapshots": "node tests/test-corex-contract-snapshots.js",
+    "test:source-snapshots": "node tests/test-source-snapshot-resolver.js",
     "test:skill-candidate-ingestion": "node tests/test-skill-candidate-ingestion.js",
     "test": "npm run lint && npm run test:data && npm run test:mcp"
   },

--- a/scripts/build-skill-candidates.js
+++ b/scripts/build-skill-candidates.js
@@ -397,6 +397,29 @@ function licenseStatus(license) {
   };
 }
 
+function licenseStatusFromSnapshot(snapshot) {
+  const license = snapshot?.metadata?.immutable?.license_status;
+  if (!license?.status) return null;
+  return {
+    status: license.status,
+    identifier: license.identifier || null,
+    source: license.source || null,
+    notes: toArray(license.notes),
+  };
+}
+
+function isImmutableSourceSnapshot(snapshot) {
+  const immutable = snapshot?.metadata?.immutable || {};
+  return snapshot?.source_type === "repository"
+    && immutable.provider === "github"
+    && /^[a-f0-9]{40}$/i.test(String(immutable.resolved_commit_sha || ""))
+    && /^[a-f0-9]{40}$/i.test(String(immutable.resolved_tree_sha || ""))
+    && /^sha256:[a-f0-9]{64}$/i.test(String(immutable.evidence_digest || ""))
+    && String(snapshot?.source_ref || "").endsWith(`@${immutable.resolved_commit_sha}`)
+    && toArray(immutable.evidence_manifest?.evidence).some((item) => item.kind === "readme")
+    && toArray(immutable.evidence_manifest?.evidence).some((item) => item.kind === "license");
+}
+
 function textForScanning(candidateInput) {
   return stableStringify(candidateInput);
 }
@@ -507,6 +530,15 @@ function conflictFindings(candidate, knowledgeArtifact, existingSkillIndex) {
     });
   }
 
+  if (!isImmutableSourceSnapshot(knowledgeArtifact?.sourceSnapshot || candidate.__sourceSnapshot)) {
+    findings.push({
+      kind: "missing_immutable_source_snapshot",
+      severity: "blocking",
+      summary: "Candidate was generated from metadata-only cache; resolve a pinned commit/tree/evidence source snapshot before promotion.",
+      source_refs: [candidate.source_snapshot_identity?.artifact_ref, candidate.source_snapshot_identity?.source_ref].filter(Boolean),
+    });
+  }
+
   const scanText = textForScanning(candidate);
   findings.push(...patternFindings(LOCAL_PATH_PATTERNS, scanText, "absolute_local_path"));
   findings.push(...patternFindings(SECRET_PATTERNS, scanText, "secret_or_credential"));
@@ -579,13 +611,17 @@ function buildCandidate({ pair, existingSkillIndex, existingCandidates, createdA
   const safeRepo = slug(nwo);
   const lane = inferLane(knowledgeArtifact, snapshot);
   const scope = inferScope(snapshot, knowledgeArtifact);
-  const license = licenseStatus(snapshot?.provenance?.license || snapshot?.metadata?.license || null);
+  const immutableSnapshot = isImmutableSourceSnapshot(snapshot);
+  const license = licenseStatusFromSnapshot(snapshot) || licenseStatus(snapshot?.provenance?.license || snapshot?.metadata?.license || null);
   const required = inferRequiredToolsAndServices(lane, knowledgeArtifact);
   const suggestedSkillId = `vega-${safeRepo}`;
   const provenanceReferences = unique([
     snapshot?.artifact_ref,
     `vega:data/repo-signals.json#${nwo}`,
     `vega:data/skill-extractions.json#${nwo}`,
+    ...toArray(snapshot?.provenance?.source_refs),
+    ...toArray(snapshot?.provenance?.derived_from),
+    snapshot?.provenance?.evidence_digest ? `vega:evidence:${snapshot.provenance.evidence_digest}` : null,
     ...toArray(knowledgeArtifact?.provenance?.source_refs),
     ...toArray(knowledgeArtifact?.provenance?.evidence_refs),
   ]);
@@ -612,11 +648,18 @@ function buildCandidate({ pair, existingSkillIndex, existingCandidates, createdA
     suggested_scope: scope,
     required_tools_services: required,
     license_status: license,
-    compatibility_assumptions: [
-      "Generated from Vega metadata, repo signals, and skill extraction cache only.",
-      "No third-party source code or long README bodies are copied into this candidate.",
-      "Promotion requires human review and a separate Core-X registry/docs change.",
-    ],
+    compatibility_assumptions: immutableSnapshot
+      ? [
+        "Generated from Vega metadata plus a pinned immutable GitHub source snapshot.",
+        "Candidate identity binds resolved commit, tree, README digest, license digest, consumed manifest digests, and aggregate evidence digest.",
+        "No third-party source code or long README bodies are copied into this candidate.",
+        "Promotion requires human review and a separate Core-X registry/docs change.",
+      ]
+      : [
+        "Generated from Vega metadata, repo signals, and skill extraction cache only.",
+        "No third-party source code or long README bodies are copied into this candidate.",
+        "Promotion is blocked until a pinned immutable source snapshot is resolved.",
+      ],
     evidence_summary: buildEvidenceSummary(knowledgeArtifact, snapshot),
     duplicate_matches: [],
     conflict_findings: [],
@@ -628,7 +671,9 @@ function buildCandidate({ pair, existingSkillIndex, existingCandidates, createdA
   };
 
   base.duplicate_matches = duplicateMatches(base, existingSkillIndex, existingCandidates);
+  base.__sourceSnapshot = snapshot;
   base.conflict_findings = conflictFindings(base, knowledgeArtifact, existingSkillIndex);
+  delete base.__sourceSnapshot;
   base.risk_findings = riskFindings(base, knowledgeArtifact);
   base.content_checksum = candidateContentChecksum(base);
   base.draft_skill_md = draftSkillMarkdown(base);
@@ -641,6 +686,12 @@ export function validateSkillCandidate(candidate) {
   const blockers = [
     ...patternFindings(LOCAL_PATH_PATTERNS, scanText, "absolute_local_path"),
     ...patternFindings(SECRET_PATTERNS, scanText, "secret_or_credential"),
+    ...toArray(candidate?.conflict_findings)
+      .filter((finding) => finding.severity === "blocking")
+      .map((finding) => ({ ...finding })),
+    ...toArray(candidate?.risk_findings)
+      .filter((finding) => finding.severity === "blocking")
+      .map((finding) => ({ ...finding })),
   ];
   const computedChecksum = candidate ? candidateContentChecksum(candidate) : "";
   const checksumOk = candidate?.content_checksum === computedChecksum;

--- a/scripts/export-corex-contracts.js
+++ b/scripts/export-corex-contracts.js
@@ -4,6 +4,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { findCachedSourceSnapshot } from "./source-snapshot-resolver.js";
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const projectRoot = path.resolve(__dirname, "..");
@@ -210,6 +212,15 @@ function buildSourceSnapshot({ repo, signal, extraction, scope, createdAt }) {
   };
 }
 
+async function loadImmutableSourceSnapshot(root, repo) {
+  const nwo = repoNwo(repo);
+  try {
+    return await findCachedSourceSnapshot(root, nwo);
+  } catch {
+    return null;
+  }
+}
+
 function riskRecords(repo, signal, extraction) {
   const risks = [];
   const nwo = repoNwo(repo);
@@ -305,7 +316,8 @@ async function writeArtifacts(outDir, pairs) {
 
   for (const pair of pairs) {
     const safeName = slug(pair.nwo);
-    await fs.writeFile(path.join(snapshotDir, `${safeName}.json`), `${JSON.stringify(pair.sourceSnapshot, null, 2)}\n`, "utf8");
+    const snapshotName = path.basename(pair.sourceSnapshot?.artifact_ref || `${safeName}.json`);
+    await fs.writeFile(path.join(snapshotDir, snapshotName), `${JSON.stringify(pair.sourceSnapshot, null, 2)}\n`, "utf8");
     await fs.writeFile(path.join(refineryDir, `${safeName}.json`), `${JSON.stringify(pair.knowledgeArtifact, null, 2)}\n`, "utf8");
   }
 }
@@ -329,12 +341,13 @@ export async function buildCorexContractArtifacts(options = {}) {
   }
 
   const selected = selectRepos([...allReposByNwo.values()], signalsByNwo, mineSet, options);
-  const artifacts = selected.map(({ repo, signal, scope }) => {
+  const artifacts = await Promise.all(selected.map(async ({ repo, signal, scope }) => {
     const extraction = extractionsByNwo.get(repoKey(repoNwo(repo))) || null;
-    const sourceSnapshot = buildSourceSnapshot({ repo, signal, extraction, scope, createdAt });
+    const sourceSnapshot = await loadImmutableSourceSnapshot(root, repo)
+      || buildSourceSnapshot({ repo, signal, extraction, scope, createdAt });
     const knowledgeArtifact = buildKnowledgeArtifact({ repo, signal, extraction, snapshot: sourceSnapshot, scope, createdAt });
-    return { nwo: repoNwo(repo), sourceSnapshot, knowledgeArtifact };
-  });
+    return { nwo: repoNwo(repo), sourceSnapshot, knowledgeArtifact, scope };
+  }));
 
   return {
     generated_by: GENERATED_BY,

--- a/scripts/source-snapshot-resolver.js
+++ b/scripts/source-snapshot-resolver.js
@@ -1,0 +1,814 @@
+#!/usr/bin/env node
+
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import dotenv from "dotenv";
+import { Octokit } from "@octokit/rest";
+import PQueue from "p-queue";
+
+dotenv.config({ override: true });
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, "..");
+
+export const EVIDENCE_CONTRACT_VERSION = "vega.source-evidence.v1";
+export const SNAPSHOT_TOOL = {
+  tool_id: "vega.resolve_source_snapshot",
+  name: "Vega Immutable Source Snapshot Resolver",
+  version: "0.1.0",
+};
+
+const REQUIRED_EVIDENCE_GROUPS = ["readme", "license"];
+const DEFAULT_EVIDENCE_CANDIDATES = {
+  readme: ["README.md", "README", "README.rst", "README.txt", "docs/README.md"],
+  license: ["LICENSE", "LICENSE.md", "LICENSE.txt", "COPYING", "COPYING.md", "NOTICE"],
+  manifest: [
+    "package.json",
+    "pyproject.toml",
+    "Cargo.toml",
+    "deno.json",
+    "bun.lockb",
+    "go.mod",
+    "requirements.txt",
+    "SKILL.md",
+  ],
+};
+
+const PRIVATE_KEY_PATTERN = new RegExp(["BEGIN", "[A-Z ]*", "PRIVATE", "KEY"].join(" "), "i");
+const SECRET_PATTERNS = [
+  PRIVATE_KEY_PATTERN,
+  new RegExp("\\b" + "ghp" + "_[A-Za-z0-9_]{20,}\\b"),
+  new RegExp("\\b" + "sk" + "-[A-Za-z0-9_-]{20,}\\b"),
+  /\bapi[_-]?key\b\s*[:=]/i,
+  /\bsecret\b\s*[:=]/i,
+  /\btoken\b\s*[:=]/i,
+];
+
+function toArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+export function slug(value) {
+  return String(value || "unknown")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "") || "unknown";
+}
+
+function sha256Bytes(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+export function sha256Text(value) {
+  return `sha256:${sha256Bytes(Buffer.from(String(value), "utf8"))}`;
+}
+
+export function stableStringify(value) {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function stablePrettyStringify(value) {
+  return `${JSON.stringify(sortJson(value), null, 2)}\n`;
+}
+
+function sortJson(value) {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, sortJson(value[key])]));
+  }
+  return value;
+}
+
+function repoNwo(repo) {
+  return repo?.nwo || [repo?.author, repo?.name].filter(Boolean).join("/") || repo?.full_name || "";
+}
+
+export function normalizeRepository(repository) {
+  const nwo = repoNwo(repository);
+  const [owner, name] = String(nwo).split("/");
+  if (!owner || !name) {
+    throw Object.assign(new Error(`Invalid repository reference: ${nwo || JSON.stringify(repository)}`), {
+      code: "invalid_repository",
+    });
+  }
+  return {
+    ...repository,
+    owner,
+    name,
+    nwo: `${owner}/${name}`,
+    uri: repository?.url || repository?.html_url || `https://github.com/${owner}/${name}`,
+  };
+}
+
+function metadataDigest(repository, githubRepo) {
+  const normalized = normalizeRepository(repository);
+  const metadata = {
+    nwo: normalized.nwo,
+    description: repository?.description || githubRepo?.description || null,
+    primary_language: repository?.primary_language || githubRepo?.language || null,
+    topics: toArray(repository?.topics || githubRepo?.topics).map(String).sort(),
+    license: repository?.license || githubRepo?.license?.spdx_id || null,
+    default_branch: githubRepo?.default_branch || repository?.default_branch || null,
+    private: repository?.private === true || githubRepo?.private === true,
+  };
+  return {
+    metadata,
+    digest: sha256Text(stableStringify(metadata)),
+  };
+}
+
+function evidenceDigestPayload(evidenceManifest) {
+  return {
+    evidence_contract_version: evidenceManifest.evidence_contract_version,
+    repository: evidenceManifest.repository,
+    normalized_repository_metadata_digest: evidenceManifest.normalized_repository_metadata_digest,
+    evidence: evidenceManifest.evidence.map((item) => ({
+      kind: item.kind,
+      path: item.path,
+      blob_sha: item.blob_sha,
+      content_sha256: item.content_sha256,
+      size: item.size,
+    })),
+    license: evidenceManifest.license,
+  };
+}
+
+export function computeEvidenceDigest(evidenceManifest) {
+  return sha256Text(stableStringify(evidenceDigestPayload(evidenceManifest)));
+}
+
+function scanSecretMaterial(text) {
+  return SECRET_PATTERNS
+    .filter((pattern) => pattern.test(text))
+    .map((pattern) => String(pattern));
+}
+
+function detectLicense(content, fallback = null) {
+  const text = String(content || "").toLowerCase();
+  let identifier = null;
+  if (/apache license[\s\S]{0,400}version 2\.0|apache-2\.0/.test(text)) identifier = "Apache-2.0";
+  else if (/permission is hereby granted[\s\S]{0,1200}mit license|mit license/.test(text)) identifier = "MIT";
+  else if (/gnu affero general public license|agpl/.test(text)) identifier = "AGPL-3.0";
+  else if (/gnu general public license|gpl/.test(text)) identifier = "GPL-3.0";
+  else if (/mozilla public license|mpl-2\.0/.test(text)) identifier = "MPL-2.0";
+  else if (/isc license|permission to use, copy, modify, and\/or distribute this software/.test(text)) identifier = "ISC";
+  else if (/bsd 3-clause|redistribution and use in source and binary forms/.test(text)) identifier = "BSD-3-Clause";
+  else if (/unlicense/.test(text)) identifier = "Unlicense";
+  else if (/creative commons zero|cc0/.test(text)) identifier = "CC0-1.0";
+  else if (fallback && fallback !== "None" && fallback !== "NOASSERTION") identifier = fallback;
+
+  if (!identifier) {
+    return {
+      status: "review-required",
+      identifier: null,
+      notes: ["Pinned license evidence was present but did not produce a confident SPDX-compatible identifier."],
+    };
+  }
+  if (/agpl/i.test(identifier)) {
+    return {
+      status: "incompatible",
+      identifier,
+      notes: ["Pinned AGPL-style license evidence detected; promotion may conflict with distribution goals."],
+    };
+  }
+  if (/(^gpl|lgpl)/i.test(identifier)) {
+    return {
+      status: "restricted",
+      identifier,
+      notes: ["Pinned GPL-family license evidence detected; adoption scope must be reviewed."],
+    };
+  }
+  if (/(mit|apache|bsd|isc|mpl|unlicense|cc0)/i.test(identifier)) {
+    return {
+      status: "compatible",
+      identifier,
+      notes: [`Pinned license evidence appears adoption-friendly: ${identifier}.`],
+    };
+  }
+  return {
+    status: "review-required",
+    identifier,
+    notes: [`Pinned license evidence requires manual compatibility review: ${identifier}.`],
+  };
+}
+
+function cacheRoot(projectRootValue, cacheDir = null) {
+  return cacheDir
+    ? path.resolve(cacheDir)
+    : path.join(projectRootValue || projectRoot, "data", "review", "source-snapshots");
+}
+
+export function snapshotArtifactRef(nwo, commitSha, evidenceDigest) {
+  const digest = String(evidenceDigest || "").replace(/^sha256:/, "");
+  return `data/review/source-snapshots/${slug(nwo)}-${String(commitSha).slice(0, 12)}-${digest.slice(0, 12)}.json`;
+}
+
+function snapshotCachePath(projectRootValue, nwo, commitSha, evidenceDigest, cacheDir = null) {
+  const artifactRef = snapshotArtifactRef(nwo, commitSha, evidenceDigest);
+  const root = path.resolve(projectRootValue || projectRoot);
+  if (cacheDir) {
+    return path.join(cacheRoot(root, cacheDir), path.basename(artifactRef));
+  }
+  return path.join(root, artifactRef);
+}
+
+function indexPath(projectRootValue, cacheDir = null) {
+  return path.join(cacheRoot(projectRootValue || projectRoot, cacheDir), "index.json");
+}
+
+async function readJson(filePath, fallback = null) {
+  try {
+    return JSON.parse(await fs.readFile(filePath, "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") return fallback;
+    throw error;
+  }
+}
+
+async function writeJson(filePath, data) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, stablePrettyStringify(data), "utf8");
+}
+
+export async function loadSourceSnapshotIndex(projectRootValue = projectRoot, options = {}) {
+  const index = await readJson(indexPath(projectRootValue, options.cacheDir), { entries: {} });
+  return index?.entries && typeof index.entries === "object" ? index : { entries: {} };
+}
+
+export async function findCachedSourceSnapshot(projectRootValue, nwo, options = {}) {
+  const normalized = normalizeRepository({ nwo });
+  const index = await loadSourceSnapshotIndex(projectRootValue, options);
+  const entry = index.entries[normalized.nwo.toLowerCase()] || index.entries[normalized.nwo];
+  if (!entry?.artifact_ref) return null;
+  const root = path.resolve(projectRootValue || projectRoot);
+  const filePath = options.cacheDir
+    ? path.join(cacheRoot(root, options.cacheDir), path.basename(entry.artifact_ref))
+    : path.join(root, entry.artifact_ref);
+  const snapshot = await readJson(filePath, null);
+  if (!snapshot) return null;
+  const validation = validateSourceSnapshot(snapshot);
+  if (!validation.valid) return null;
+  return snapshot;
+}
+
+async function readIndexedSourceSnapshot(projectRootValue, nwo, options = {}) {
+  const normalized = normalizeRepository({ nwo });
+  const index = await loadSourceSnapshotIndex(projectRootValue, options);
+  const entry = index.entries[normalized.nwo.toLowerCase()] || index.entries[normalized.nwo];
+  if (!entry?.artifact_ref) return null;
+  const root = path.resolve(projectRootValue || projectRoot);
+  const filePath = options.cacheDir
+    ? path.join(cacheRoot(root, options.cacheDir), path.basename(entry.artifact_ref))
+    : path.join(root, entry.artifact_ref);
+  return await readJson(filePath, null);
+}
+
+export async function loadSourceSnapshot(repository, commitSha, options = {}) {
+  const normalized = normalizeRepository(repository);
+  const root = path.resolve(options.projectRoot || projectRoot);
+  const index = await loadSourceSnapshotIndex(root, options);
+  const entry = index.entries[normalized.nwo.toLowerCase()] || index.entries[normalized.nwo];
+  if (!entry || entry.resolved_commit_sha !== commitSha) return null;
+  return await findCachedSourceSnapshot(root, normalized.nwo, options);
+}
+
+async function writeSourceSnapshotCache(snapshot, options = {}) {
+  const root = path.resolve(options.projectRoot || projectRoot);
+  const nwo = snapshot.metadata?.repository?.nwo || snapshot.metadata?.nwo || snapshot.source_ref.split("@")[0];
+  const commitSha = snapshot.metadata?.immutable?.resolved_commit_sha;
+  const evidenceDigest = snapshot.metadata?.immutable?.evidence_digest;
+  const filePath = snapshotCachePath(root, nwo, commitSha, evidenceDigest, options.cacheDir);
+  await writeJson(filePath, snapshot);
+
+  const index = await loadSourceSnapshotIndex(root, options);
+  const key = String(nwo).toLowerCase();
+  index.entries[key] = {
+    nwo,
+    artifact_ref: snapshot.artifact_ref,
+    snapshot_id: snapshot.id,
+    resolved_commit_sha: commitSha,
+    resolved_tree_sha: snapshot.metadata?.immutable?.resolved_tree_sha,
+    evidence_contract_version: EVIDENCE_CONTRACT_VERSION,
+    evidence_digest: evidenceDigest,
+  };
+  await writeJson(indexPath(root, options.cacheDir), index);
+}
+
+class OctokitGitHubClient {
+  constructor({ token = process.env.GITHUB_TOKEN || process.env.GH_PAT || null, retries = 2, retryBaseMs = 500 } = {}) {
+    this.octokit = new Octokit(token ? { auth: token } : undefined);
+    this.retries = retries;
+    this.retryBaseMs = retryBaseMs;
+  }
+
+  async retry(operation) {
+    let attempt = 0;
+    while (true) {
+      try {
+        return await operation();
+      } catch (error) {
+        const retryable = [429, 500, 502, 503, 504].includes(Number(error?.status));
+        if (!retryable || attempt >= this.retries) throw error;
+        const waitMs = this.retryBaseMs * (2 ** attempt);
+        await new Promise((resolve) => setTimeout(resolve, waitMs));
+        attempt += 1;
+      }
+    }
+  }
+
+  async getRepository({ owner, repo }) {
+    const { data } = await this.retry(() => this.octokit.repos.get({ owner, repo }));
+    return data;
+  }
+
+  async resolveRef({ owner, repo, ref }) {
+    if (/^[a-f0-9]{40}$/i.test(ref)) return { sha: ref, ref_type: "commit" };
+    try {
+      const { data } = await this.retry(() => this.octokit.repos.getBranch({ owner, repo, branch: ref }));
+      return { sha: data.commit.sha, ref_type: "branch" };
+    } catch (branchError) {
+      try {
+        const { data } = await this.retry(() => this.octokit.git.getRef({ owner, repo, ref: `tags/${ref}` }));
+        const object = data.object;
+        if (object.type === "commit") return { sha: object.sha, ref_type: "tag" };
+        if (object.type === "tag") {
+          const tag = await this.retry(() => this.octokit.git.getTag({ owner, repo, tag_sha: object.sha }));
+          return { sha: tag.data.object.sha, ref_type: "annotated_tag" };
+        }
+      } catch {
+        // Preserve the original branch error below.
+      }
+      throw branchError;
+    }
+  }
+
+  async getCommit({ owner, repo, commitSha }) {
+    const { data } = await this.retry(() => this.octokit.git.getCommit({ owner, repo, commit_sha: commitSha }));
+    return {
+      sha: data.sha,
+      tree_sha: data.tree?.sha || null,
+      committed_at: data.committer?.date || data.author?.date || "1970-01-01T00:00:00.000Z",
+    };
+  }
+
+  async getTree({ owner, repo, treeSha }) {
+    const { data } = await this.retry(() => this.octokit.git.getTree({ owner, repo, tree_sha: treeSha }));
+    return { sha: data.sha, truncated: data.truncated === true };
+  }
+
+  async getContent({ owner, repo, filePath, ref }) {
+    const { data } = await this.retry(() => this.octokit.repos.getContent({ owner, repo, path: filePath, ref }));
+    if (Array.isArray(data) || data.type !== "file") return null;
+    const content = Buffer.from(data.content || "", data.encoding === "base64" ? "base64" : "utf8");
+    return {
+      path: data.path || filePath,
+      blob_sha: data.sha || null,
+      size: data.size ?? content.byteLength,
+      content,
+    };
+  }
+}
+
+function rateLimitDetails(error) {
+  const headers = error?.response?.headers || error?.headers || {};
+  return {
+    status: error?.status || null,
+    remaining: headers["x-ratelimit-remaining"] || headers["X-RateLimit-Remaining"] || null,
+    reset: headers["x-ratelimit-reset"] || headers["X-RateLimit-Reset"] || null,
+    resource: headers["x-ratelimit-resource"] || headers["X-RateLimit-Resource"] || null,
+  };
+}
+
+function fail(code, message, details = {}) {
+  const error = new Error(message);
+  error.code = code;
+  Object.assign(error, details);
+  throw error;
+}
+
+function internalErrorCode(error) {
+  if (!error || typeof error.status === "number") return null;
+  const descriptor = Object.getOwnPropertyDescriptor(error, "code");
+  return descriptor && Object.hasOwn(descriptor, "value") && typeof descriptor.value === "string"
+    ? descriptor.value
+    : null;
+}
+
+async function fetchFirstEvidence(client, normalized, commitSha, kind, candidates, required) {
+  for (const candidatePath of candidates) {
+    try {
+      const content = await client.getContent({
+        owner: normalized.owner,
+        repo: normalized.name,
+        filePath: candidatePath,
+        ref: commitSha,
+      });
+      if (!content) continue;
+      const secretMatches = scanSecretMaterial(content.content.toString("utf8"));
+      if (secretMatches.length > 0) {
+        fail("secret_evidence", `Secret-like material detected in ${candidatePath}`, { secretMatches });
+      }
+      return {
+        kind,
+        path: content.path || candidatePath,
+        blob_sha: content.blob_sha,
+        content_sha256: sha256Text(content.content),
+        size: content.size,
+        text_preview: content.content.toString("utf8", 0, Math.min(content.content.length, 2048)),
+      };
+    } catch (error) {
+      if (internalErrorCode(error)) throw error;
+      if (error?.status && error.status !== 404) throw error;
+    }
+  }
+  if (required) {
+    fail("missing_required_evidence", `Missing required ${kind} evidence for ${normalized.nwo}`, { kind });
+  }
+  return null;
+}
+
+async function fetchEvidence(client, normalized, commitSha, evidenceCandidates = DEFAULT_EVIDENCE_CANDIDATES) {
+  const evidence = [];
+  for (const [kind, candidates] of Object.entries(evidenceCandidates)) {
+    const required = REQUIRED_EVIDENCE_GROUPS.includes(kind);
+    if (kind === "manifest") {
+      for (const candidatePath of candidates) {
+        const item = await fetchFirstEvidence(client, normalized, commitSha, "manifest", [candidatePath], false);
+        if (item) evidence.push(item);
+      }
+    } else {
+      const item = await fetchFirstEvidence(client, normalized, commitSha, kind, candidates, required);
+      if (item) evidence.push(item);
+    }
+  }
+  return evidence;
+}
+
+function buildEvidenceManifest({ repository, githubRepo, requestedRef, refType, commit, tree, evidence }) {
+  const normalized = normalizeRepository(repository);
+  const { metadata, digest } = metadataDigest(repository, githubRepo);
+  const licenseEvidence = evidence.find((item) => item.kind === "license") || null;
+  const pinnedLicense = detectLicense(licenseEvidence?.text_preview, metadata.license);
+  const license = {
+    ...pinnedLicense,
+    source: licenseEvidence
+      ? `pinned-license-file:${licenseEvidence.path}@${licenseEvidence.blob_sha || licenseEvidence.content_sha256}`
+      : "missing-pinned-license-evidence",
+    evidence_ref: licenseEvidence
+      ? `${licenseEvidence.path}:${licenseEvidence.blob_sha || licenseEvidence.content_sha256}`
+      : null,
+  };
+  const manifest = {
+    evidence_contract_version: EVIDENCE_CONTRACT_VERSION,
+    repository: {
+      provider: "github",
+      nwo: normalized.nwo,
+      requested_ref: requestedRef,
+      ref_type: refType,
+      resolved_commit_sha: commit.sha,
+      resolved_tree_sha: tree.sha,
+    },
+    normalized_repository_metadata_digest: digest,
+    evidence: evidence
+      .map((item) => ({
+        kind: item.kind,
+        path: item.path,
+        blob_sha: item.blob_sha,
+        content_sha256: item.content_sha256,
+        size: item.size,
+      }))
+      .sort((a, b) => `${a.kind}:${a.path}`.localeCompare(`${b.kind}:${b.path}`)),
+    license,
+  };
+  return {
+    ...manifest,
+    evidence_digest: computeEvidenceDigest(manifest),
+    normalized_repository_metadata: metadata,
+  };
+}
+
+export function validateSourceSnapshot(snapshot) {
+  const blockers = [];
+  const immutable = snapshot?.metadata?.immutable || {};
+  const evidenceManifest = immutable.evidence_manifest || {};
+  if (snapshot?.source_type !== "repository") blockers.push("source_type is not repository");
+  if (immutable.provider !== "github") blockers.push("provider is not github");
+  if (!/^[a-f0-9]{40}$/i.test(String(immutable.resolved_commit_sha || ""))) blockers.push("resolved commit SHA missing or invalid");
+  if (!/^[a-f0-9]{40}$/i.test(String(immutable.resolved_tree_sha || ""))) blockers.push("resolved tree SHA missing or invalid");
+  if (immutable.evidence_contract_version !== EVIDENCE_CONTRACT_VERSION) blockers.push("evidence contract version mismatch");
+  if (!/^sha256:[a-f0-9]{64}$/i.test(String(immutable.evidence_digest || ""))) blockers.push("evidence digest missing or invalid");
+  if (evidenceManifest.evidence_contract_version) {
+    const recomputed = computeEvidenceDigest(evidenceManifest);
+    if (recomputed !== immutable.evidence_digest) blockers.push("evidence digest does not match evidence manifest");
+  }
+  if (!String(snapshot?.id || "").includes(String(immutable.resolved_commit_sha || "").slice(0, 12))) blockers.push("snapshot id does not bind commit");
+  if (!String(snapshot?.id || "").includes(String(immutable.evidence_digest || "").replace(/^sha256:/, "").slice(0, 12))) blockers.push("snapshot id does not bind evidence digest");
+  const evidence = toArray(immutable.evidence_manifest?.evidence);
+  if (!evidence.some((item) => item.kind === "readme")) blockers.push("pinned README evidence missing");
+  if (!evidence.some((item) => item.kind === "license")) blockers.push("pinned license evidence missing");
+  if (String(snapshot?.provenance?.commit || "") !== String(immutable.resolved_commit_sha || "")) blockers.push("provenance commit mismatch");
+  if (String(snapshot?.provenance?.tree || "") !== String(immutable.resolved_tree_sha || "")) blockers.push("provenance tree mismatch");
+  if (!String(snapshot?.source_ref || "").endsWith(`@${immutable.resolved_commit_sha}`)) blockers.push("source ref does not bind resolved commit");
+  if (!String(snapshot?.artifact_ref || "").endsWith(`${String(immutable.evidence_digest || "").replace(/^sha256:/, "").slice(0, 12)}.json`)) {
+    blockers.push("artifact ref does not bind evidence digest");
+  }
+  return { valid: blockers.length === 0, blockers };
+}
+
+export function buildSourceSnapshotFromEvidence({ repository, githubRepo, requestedRef, refType, commit, tree, evidence }) {
+  const normalized = normalizeRepository(repository);
+  if (!commit?.sha) fail("missing_commit", `Commit could not be resolved for ${normalized.nwo}`);
+  if (!tree?.sha) fail("missing_tree", `Tree could not be resolved for ${normalized.nwo}@${commit.sha}`);
+  if (tree.truncated === true) fail("tree_truncated", `Tree response is truncated for ${normalized.nwo}@${commit.sha}`);
+  const evidenceManifest = buildEvidenceManifest({ repository, githubRepo, requestedRef, refType, commit, tree, evidence });
+  const evidenceDigest = evidenceManifest.evidence_digest;
+  const digestBare = evidenceDigest.replace(/^sha256:/, "");
+  const snapshotId = `vega:source-snapshot:${slug(normalized.nwo)}:${commit.sha.slice(0, 12)}:${tree.sha.slice(0, 12)}:${digestBare.slice(0, 12)}`;
+  const artifactRef = snapshotArtifactRef(normalized.nwo, commit.sha, evidenceDigest);
+  const contentSize = evidence.reduce((sum, item) => sum + Number(item.size || 0), 0);
+  const snapshot = {
+    id: snapshotId,
+    source_type: "repository",
+    source_uri: normalized.uri,
+    source_ref: `${normalized.nwo}@${commit.sha}`,
+    created_at: commit.committed_at || "1970-01-01T00:00:00.000Z",
+    created_by: "vega-lab:resolve-source-snapshots",
+    tool: SNAPSHOT_TOOL,
+    include_patterns: evidenceManifest.evidence.map((item) => `${item.kind}:${item.path}`),
+    exclude_patterns: ["raw repository tree beyond consumed evidence", "tokens", "secrets", "private file contents"],
+    token_estimate: {
+      tokens: Math.ceil(contentSize / 4),
+      method: "pinned-evidence-bytes/4",
+      confidence: "verified",
+    },
+    secret_scan: {
+      status: "passed",
+      tool: "vega-source-snapshot-secret-patterns",
+      findings_count: 0,
+      redaction_applied: false,
+      report_ref: null,
+    },
+    provenance: {
+      source_refs: [
+        `github:${normalized.nwo}@${commit.sha}`,
+        `github:${normalized.nwo}:tree:${tree.sha}`,
+        `vega:evidence:${evidenceDigest}`,
+      ],
+      derived_from: [
+        `${normalized.nwo}@${requestedRef}`,
+        `commit:${commit.sha}`,
+        `tree:${tree.sha}`,
+      ],
+      commit: commit.sha,
+      tree: tree.sha,
+      requested_ref: requestedRef,
+      license: evidenceManifest.license.identifier,
+      evidence_digest: evidenceDigest,
+    },
+    artifact_ref: artifactRef,
+    review_status: "pending",
+    metadata: {
+      nwo: normalized.nwo,
+      repository: {
+        provider: "github",
+        owner: normalized.owner,
+        name: normalized.name,
+        nwo: normalized.nwo,
+        uri: normalized.uri,
+      },
+      immutable: {
+        provider: "github",
+        requested_ref: requestedRef,
+        ref_type: refType,
+        resolved_commit_sha: commit.sha,
+        resolved_tree_sha: tree.sha,
+        evidence_contract_version: EVIDENCE_CONTRACT_VERSION,
+        evidence_digest: evidenceDigest,
+        evidence_manifest: evidenceManifest,
+        normalized_repository_metadata_digest: evidenceManifest.normalized_repository_metadata_digest,
+        license_status: evidenceManifest.license,
+      },
+      ...evidenceManifest.normalized_repository_metadata,
+    },
+  };
+  const validation = validateSourceSnapshot(snapshot);
+  if (!validation.valid) {
+    fail("invalid_source_snapshot", `Resolved source snapshot failed validation for ${normalized.nwo}`, { validation });
+  }
+  return snapshot;
+}
+
+export async function resolveSourceSnapshot(repository, options = {}) {
+  const root = path.resolve(options.projectRoot || projectRoot);
+  const normalized = normalizeRepository(repository);
+  const client = options.client || new OctokitGitHubClient(options);
+  const githubRepo = await client.getRepository({ owner: normalized.owner, repo: normalized.name });
+  if (githubRepo?.private && !options.allowPrivate) {
+    fail("repository_unavailable", `${normalized.nwo} is private or unavailable without explicit private handling.`);
+  }
+  const requestedRef = options.ref || repository.default_branch || githubRepo.default_branch || "HEAD";
+  let ref;
+  try {
+    ref = await client.resolveRef({ owner: normalized.owner, repo: normalized.name, ref: requestedRef });
+  } catch (error) {
+    const code = Number(error?.status) === 403 ? "rate_limit_or_forbidden" : "ref_unavailable";
+    fail(code, `Could not resolve ${normalized.nwo}@${requestedRef}`, { cause: error, rate_limit: rateLimitDetails(error) });
+  }
+  let commit;
+  let tree;
+  try {
+    commit = await client.getCommit({ owner: normalized.owner, repo: normalized.name, commitSha: ref.sha });
+    if (!commit?.sha) fail("missing_commit", `Missing commit for ${normalized.nwo}@${ref.sha}`);
+    if (!commit?.tree_sha) fail("missing_tree", `Missing tree for ${normalized.nwo}@${commit.sha}`);
+    const cached = await loadSourceSnapshot(normalized, commit.sha, { projectRoot: root, cacheDir: options.cacheDir });
+    if (cached) {
+      return { snapshot: cached, cache_hit: true, wrote: false, rate_limit: null };
+    }
+    tree = await client.getTree({ owner: normalized.owner, repo: normalized.name, treeSha: commit.tree_sha });
+    if (tree?.truncated) fail("tree_truncated", `Tree response is truncated for ${normalized.nwo}@${commit.sha}`);
+  } catch (error) {
+    fail(internalErrorCode(error) || "commit_or_tree_unavailable", error.message, { cause: error, rate_limit: rateLimitDetails(error) });
+  }
+  let evidence;
+  try {
+    evidence = await fetchEvidence(client, normalized, commit.sha, options.evidenceCandidates || DEFAULT_EVIDENCE_CANDIDATES);
+  } catch (error) {
+    fail(internalErrorCode(error) || "evidence_unavailable", error.message, { cause: error, rate_limit: rateLimitDetails(error) });
+  }
+  const snapshot = buildSourceSnapshotFromEvidence({
+    repository: normalized,
+    githubRepo,
+    requestedRef,
+    refType: ref.ref_type,
+    commit,
+    tree,
+    evidence,
+  });
+  if (options.write !== false) {
+    await writeSourceSnapshotCache(snapshot, { projectRoot: root, cacheDir: options.cacheDir });
+  }
+  return { snapshot, cache_hit: false, wrote: options.write !== false, rate_limit: null };
+}
+
+export async function checkSourceSnapshot(repository, options = {}) {
+  const root = path.resolve(options.projectRoot || projectRoot);
+  const normalized = normalizeRepository(repository);
+  const snapshot = await readIndexedSourceSnapshot(root, normalized.nwo, options);
+  if (!snapshot) {
+    return {
+      ok: false,
+      nwo: normalized.nwo,
+      cache_hit: false,
+      blockers: ["offline cache miss"],
+    };
+  }
+  const validation = validateSourceSnapshot(snapshot);
+  return {
+    ok: validation.valid,
+    nwo: normalized.nwo,
+    cache_hit: true,
+    blockers: validation.blockers,
+    snapshot_id: snapshot.id,
+    commit: snapshot.metadata?.immutable?.resolved_commit_sha,
+    tree: snapshot.metadata?.immutable?.resolved_tree_sha,
+    evidence_digest: snapshot.metadata?.immutable?.evidence_digest,
+  };
+}
+
+async function readReposFromInput(filePath) {
+  const payload = JSON.parse(await fs.readFile(filePath, "utf8"));
+  if (Array.isArray(payload)) return payload.map((item) => typeof item === "string" ? { nwo: item } : item);
+  if (Array.isArray(payload?.repositories)) return payload.repositories;
+  if (Array.isArray(payload?.candidate_ids)) return payload.candidate_ids.map((candidateId) => ({
+    nwo: String(candidateId).replace(/^vega\.skill-candidate:/, "").replace(/-/g, "/"),
+  }));
+  return [];
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    repos: [],
+    input: null,
+    limit: 25,
+    concurrency: 2,
+    check: false,
+    ref: null,
+    projectRoot,
+    cacheDir: null,
+    json: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--repo") {
+      options.repos.push({ nwo: argv[index + 1] });
+      index += 1;
+    } else if (arg.startsWith("--repo=")) {
+      options.repos.push({ nwo: arg.slice("--repo=".length) });
+    } else if (arg === "--input") {
+      options.input = argv[index + 1];
+      index += 1;
+    } else if (arg.startsWith("--input=")) {
+      options.input = arg.slice("--input=".length);
+    } else if (arg === "--limit") {
+      options.limit = Number.parseInt(argv[index + 1] || "", 10);
+      index += 1;
+    } else if (arg.startsWith("--limit=")) {
+      options.limit = Number.parseInt(arg.slice("--limit=".length), 10);
+    } else if (arg === "--concurrency") {
+      options.concurrency = Number.parseInt(argv[index + 1] || "", 10);
+      index += 1;
+    } else if (arg.startsWith("--concurrency=")) {
+      options.concurrency = Number.parseInt(arg.slice("--concurrency=".length), 10);
+    } else if (arg === "--ref") {
+      options.ref = argv[index + 1] || null;
+      index += 1;
+    } else if (arg.startsWith("--ref=")) {
+      options.ref = arg.slice("--ref=".length);
+    } else if (arg === "--project-root") {
+      options.projectRoot = path.resolve(argv[index + 1] || options.projectRoot);
+      index += 1;
+    } else if (arg.startsWith("--project-root=")) {
+      options.projectRoot = path.resolve(arg.slice("--project-root=".length));
+    } else if (arg === "--cache-dir") {
+      options.cacheDir = path.resolve(argv[index + 1] || "");
+      index += 1;
+    } else if (arg.startsWith("--cache-dir=")) {
+      options.cacheDir = path.resolve(arg.slice("--cache-dir=".length));
+    } else if (arg === "--check" || arg === "--offline") {
+      options.check = true;
+    } else if (arg === "--json") {
+      options.json = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!Number.isFinite(options.limit) || options.limit < 1) options.limit = 25;
+  if (!Number.isFinite(options.concurrency) || options.concurrency < 1) options.concurrency = 1;
+  return options;
+}
+
+export async function runResolveSourceSnapshots(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  const inputRepos = options.input ? await readReposFromInput(options.input) : [];
+  const repos = [...options.repos, ...inputRepos].slice(0, options.limit);
+  const queue = new PQueue({ concurrency: options.concurrency });
+  const results = [];
+  await Promise.all(repos.map((repo) => queue.add(async () => {
+    try {
+      const normalized = normalizeRepository(repo);
+      if (options.check) {
+        results.push(await checkSourceSnapshot(normalized, options));
+        return;
+      }
+      const result = await resolveSourceSnapshot(normalized, {
+        projectRoot: options.projectRoot,
+        cacheDir: options.cacheDir,
+        ref: options.ref,
+      });
+      results.push({
+        ok: true,
+        nwo: normalized.nwo,
+        cache_hit: result.cache_hit,
+        wrote: result.wrote,
+        snapshot_id: result.snapshot.id,
+        commit: result.snapshot.metadata?.immutable?.resolved_commit_sha,
+        tree: result.snapshot.metadata?.immutable?.resolved_tree_sha,
+        evidence_digest: result.snapshot.metadata?.immutable?.evidence_digest,
+        artifact_ref: result.snapshot.artifact_ref,
+      });
+    } catch (error) {
+      results.push({
+        ok: false,
+        nwo: repoNwo(repo),
+        code: internalErrorCode(error) || "resolve_failed",
+        message: error.message,
+        rate_limit: error.rate_limit || rateLimitDetails(error.cause || error),
+      });
+    }
+  })));
+  const summary = {
+    generated_by: "vega-lab:resolve-source-snapshots",
+    check: options.check,
+    requested_count: repos.length,
+    ok_count: results.filter((item) => item.ok).length,
+    failed_count: results.filter((item) => !item.ok).length,
+    results: results.sort((a, b) => String(a.nwo).localeCompare(String(b.nwo))),
+  };
+  console.log(JSON.stringify(summary, null, 2));
+  return summary;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runResolveSourceSnapshots().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/tests/test-mcp-server.js
+++ b/tests/test-mcp-server.js
@@ -139,8 +139,12 @@ async function main() {
       name: "validate_skill_candidate",
       arguments: { candidate_id: skillCandidate.candidate_id, limit: 1 },
     }));
-    assert.equal(skillValidationResult.validation.valid, true, "MCP candidate validation should pass");
+    assert.equal(skillValidationResult.validation.valid, false, "Metadata-only MCP candidate validation should be blocked before promotion");
     assert.equal(skillValidationResult.validation.checksum_ok, true, "MCP candidate checksum should match canonical content");
+    assert.ok(
+      skillValidationResult.validation.blockers.some((blocker) => blocker.kind === "missing_immutable_source_snapshot"),
+      "MCP validation should expose the immutable source snapshot precondition",
+    );
 
     const skillProposalResult = parseTextPayload(await client.callTool({
       name: "propose_skill_promotion",

--- a/tests/test-skill-candidate-ingestion.js
+++ b/tests/test-skill-candidate-ingestion.js
@@ -17,6 +17,10 @@ import {
   validateSkillReview,
   validateSkillCandidate,
 } from "../scripts/build-skill-candidates.js";
+import {
+  buildSourceSnapshotFromEvidence,
+  stablePrettyStringify,
+} from "../scripts/source-snapshot-resolver.js";
 
 async function writeJson(filePath, data) {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
@@ -30,6 +34,76 @@ async function exists(filePath) {
   } catch {
     return false;
   }
+}
+
+async function writeImmutableSnapshot(projectRoot, repo) {
+  const commitSha = "a".repeat(40);
+  const treeSha = "b".repeat(40);
+  const snapshot = buildSourceSnapshotFromEvidence({
+    repository: repo,
+    githubRepo: {
+      default_branch: "main",
+      description: repo.description,
+      language: repo.primary_language,
+      license: { spdx_id: repo.license },
+      topics: repo.topics,
+      private: false,
+    },
+    requestedRef: "main",
+    refType: "branch",
+    commit: {
+      sha: commitSha,
+      tree_sha: treeSha,
+      committed_at: "2026-06-12T00:00:00.000Z",
+    },
+    tree: {
+      sha: treeSha,
+      truncated: false,
+    },
+    evidence: [
+      {
+        kind: "readme",
+        path: "README.md",
+        blob_sha: "c".repeat(40),
+        content_sha256: "sha256:35a528211dbf54569e622969c569685ea27156d37373637c4751ded08e9d3f4e",
+        size: 52,
+        text_preview: "# Agent Toolkit\n\nDeterministic agent workflow toolkit.",
+      },
+      {
+        kind: "license",
+        path: "LICENSE",
+        blob_sha: "d".repeat(40),
+        content_sha256: "sha256:2c73f0eec270c48d35dbe2f0b742d3a45eb1fda715d9c98a5d271610000784f7",
+        size: 38,
+        text_preview: "MIT License\n\nPermission is hereby granted...",
+      },
+      {
+        kind: "manifest",
+        path: "package.json",
+        blob_sha: "e".repeat(40),
+        content_sha256: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        size: 28,
+        text_preview: "{\"name\":\"agent-toolkit\"}",
+      },
+    ],
+  });
+  const snapshotPath = path.join(projectRoot, snapshot.artifact_ref);
+  await fs.mkdir(path.dirname(snapshotPath), { recursive: true });
+  await fs.writeFile(snapshotPath, stablePrettyStringify(snapshot), "utf8");
+  await writeJson(path.join(projectRoot, "data", "review", "source-snapshots", "index.json"), {
+    entries: {
+      "example/agent-toolkit": {
+        nwo: "example/agent-toolkit",
+        artifact_ref: snapshot.artifact_ref,
+        snapshot_id: snapshot.id,
+        resolved_commit_sha: snapshot.metadata.immutable.resolved_commit_sha,
+        resolved_tree_sha: snapshot.metadata.immutable.resolved_tree_sha,
+        evidence_contract_version: snapshot.metadata.immutable.evidence_contract_version,
+        evidence_digest: snapshot.metadata.immutable.evidence_digest,
+      },
+    },
+  });
+  return snapshot;
 }
 
 async function main() {
@@ -77,6 +151,19 @@ async function main() {
       "utf8",
     );
 
+    const metadataOnly = await buildSkillCandidateIngestion({
+      projectRoot,
+      corexRoot,
+      outDir: path.join(projectRoot, "data", "review"),
+      dryRun: true,
+      limit: 1,
+      createdAt: "2026-06-13T00:00:00.000Z",
+    });
+    assert.ok(metadataOnly.candidates[0].conflict_findings.some((finding) => finding.kind === "missing_immutable_source_snapshot"));
+    assert.equal(validateSkillCandidate(metadataOnly.candidates[0]).valid, false);
+
+    await writeImmutableSnapshot(projectRoot, repo);
+
     process.chdir(projectRoot);
     const outDir = path.join(projectRoot, "data", "review");
     const result = await buildSkillCandidateIngestion({
@@ -98,8 +185,13 @@ async function main() {
     assert.equal(candidate.candidate_id, "vega.skill-candidate:example-agent-toolkit");
     assert.equal(candidate.review_status, "pending");
     assert.equal(candidate.source_repository.nwo, "example/agent-toolkit");
+    assert.match(candidate.source_snapshot_identity.source_ref, /example\/agent-toolkit@[a-f0-9]{40}/);
+    assert.ok(candidate.provenance_references.some((ref) => /^github:example\/agent-toolkit@[a-f0-9]{40}$/.test(ref)));
+    assert.ok(candidate.provenance_references.some((ref) => /^github:example\/agent-toolkit:tree:[a-f0-9]{40}$/.test(ref)));
+    assert.ok(candidate.provenance_references.some((ref) => /^vega:evidence:sha256:[a-f0-9]{64}$/.test(ref)));
     assert.equal(candidate.suggested_corex_lane, "agent-workflows");
     assert.equal(candidate.license_status.status, "compatible");
+    assert.match(candidate.license_status.source, /^pinned-license-file:/);
     assert.deepEqual(Object.keys(candidate.required_tools_services).sort(), ["services", "tools"]);
     assert.ok(candidate.duplicate_matches.some((match) => match.kind === "duplicate_id"));
     assert.ok(candidate.content_checksum.startsWith("sha256:"));

--- a/tests/test-source-snapshot-resolver.js
+++ b/tests/test-source-snapshot-resolver.js
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { buildSkillCandidateIngestion } from "../scripts/build-skill-candidates.js";
+import {
+  checkSourceSnapshot,
+  resolveSourceSnapshot,
+  runResolveSourceSnapshots,
+  stablePrettyStringify,
+} from "../scripts/source-snapshot-resolver.js";
+
+const COMMIT_A = "a".repeat(40);
+const COMMIT_B = "b".repeat(40);
+const TREE_A = "c".repeat(40);
+const TREE_B = "d".repeat(40);
+
+class FixtureGitHubClient {
+  constructor() {
+    this.branchSha = COMMIT_A;
+    this.private = false;
+    this.truncatedTree = false;
+    this.rateLimit = false;
+    this.files = new Map([
+      [COMMIT_A, new Map([
+        ["README.md", "# Skill Seekers\n\nResearch workflow and skill discovery patterns."],
+        ["LICENSE", "MIT License\n\nPermission is hereby granted..."],
+        ["package.json", "{\"name\":\"skill-seekers\",\"version\":\"1.0.0\"}"],
+      ])],
+      [COMMIT_B, new Map([
+        ["README.md", "# Skill Seekers\n\nResearch workflow, prompt routing, and capability discovery patterns."],
+        ["LICENSE", "MIT License\n\nPermission is hereby granted..."],
+        ["package.json", "{\"name\":\"skill-seekers\",\"version\":\"1.1.0\"}"],
+      ])],
+    ]);
+  }
+
+  async getRepository() {
+    return {
+      default_branch: "main",
+      description: "Skill discovery patterns for agent teams.",
+      language: "Python",
+      license: { spdx_id: "MIT" },
+      topics: ["agents", "skills", "research"],
+      private: this.private,
+    };
+  }
+
+  async resolveRef({ ref }) {
+    if (this.rateLimit) {
+      const error = new Error("rate limited");
+      error.status = 403;
+      error.headers = { "x-ratelimit-remaining": "0" };
+      throw error;
+    }
+    if (/^[a-f0-9]{40}$/i.test(ref)) return { sha: ref, ref_type: "commit" };
+    return { sha: this.branchSha, ref_type: "branch" };
+  }
+
+  async getCommit({ commitSha }) {
+    if (commitSha === COMMIT_A) return { sha: COMMIT_A, tree_sha: TREE_A, committed_at: "2026-06-01T00:00:00.000Z" };
+    if (commitSha === COMMIT_B) return { sha: COMMIT_B, tree_sha: TREE_B, committed_at: "2026-06-02T00:00:00.000Z" };
+    const error = new Error("missing commit");
+    error.status = 404;
+    throw error;
+  }
+
+  async getTree({ treeSha }) {
+    return { sha: treeSha, truncated: this.truncatedTree };
+  }
+
+  async getContent({ filePath, ref }) {
+    const files = this.files.get(ref);
+    const text = files?.get(filePath);
+    if (!text) {
+      const error = new Error("not found");
+      error.status = 404;
+      throw error;
+    }
+    return {
+      path: filePath,
+      blob_sha: `${filePath.length.toString(16).padStart(40, "0")}`,
+      size: Buffer.byteLength(text),
+      content: Buffer.from(text, "utf8"),
+    };
+  }
+}
+
+async function writeJson(filePath, data) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+}
+
+async function seedVegaCaches(projectRoot) {
+  const repo = {
+    nwo: "yusufkaraaslan/Skill_Seekers",
+    name: "Skill_Seekers",
+    author: "yusufkaraaslan",
+    description: "Skill discovery patterns for agent teams.",
+    url: "https://github.com/yusufkaraaslan/Skill_Seekers",
+    stars: 99,
+    forks: 7,
+    primary_language: "Python",
+    topics: ["agents", "skills", "research"],
+    license: "MIT",
+  };
+  await writeJson(path.join(projectRoot, "data", "data.json"), [repo]);
+  await writeJson(path.join(projectRoot, "data", "my-repos.json"), []);
+  await writeJson(path.join(projectRoot, "data", "repo-signals.json"), [{
+    nwo: "yusufkaraaslan/Skill_Seekers",
+    adoptionScore: 91,
+    adoptionKind: "tool",
+    capabilities: ["agent-workflows", "research-intelligence"],
+    houseSkills: ["skill-extraction"],
+  }]);
+  await writeJson(path.join(projectRoot, "data", "skill-extractions.json"), [{
+    nwo: "yusufkaraaslan/Skill_Seekers",
+    summary: "Agent team skill discovery and routing workflow patterns.",
+    capabilities: ["agent-workflows"],
+    houseSkills: ["skill-extraction"],
+    flows: ["skill-discovery"],
+    adoptionKind: "tool",
+  }]);
+  return repo;
+}
+
+async function firstCandidate(projectRoot, corexRoot) {
+  const result = await buildSkillCandidateIngestion({
+    projectRoot,
+    corexRoot,
+    outDir: path.join(projectRoot, "data", "review"),
+    dryRun: true,
+    limit: 1,
+    createdAt: "2026-06-13T00:00:00.000Z",
+  });
+  assert.equal(result.candidates.length, 1);
+  return result.candidates[0];
+}
+
+async function assertRejectsCode(promise, code) {
+  await assert.rejects(promise, (error) => {
+    assert.equal(error.code, code);
+    return true;
+  });
+}
+
+async function main() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "vega-source-snapshots-"));
+  const projectRoot = path.join(root, "vega-lab");
+  const corexRoot = path.join(root, "core-x");
+  const client = new FixtureGitHubClient();
+  const repo = await seedVegaCaches(projectRoot);
+  await fs.mkdir(path.join(corexRoot, "skills"), { recursive: true });
+
+  try {
+    const first = await resolveSourceSnapshot(repo, { projectRoot, client, write: false });
+    const second = await resolveSourceSnapshot(repo, { projectRoot, client, write: false });
+    assert.equal(stablePrettyStringify(first.snapshot), stablePrettyStringify(second.snapshot));
+    assert.equal(first.snapshot.metadata.immutable.resolved_commit_sha, COMMIT_A);
+    assert.equal(first.snapshot.metadata.immutable.resolved_tree_sha, TREE_A);
+    assert.match(first.snapshot.metadata.immutable.evidence_digest, /^sha256:[a-f0-9]{64}$/);
+    assert.ok(first.snapshot.metadata.immutable.evidence_manifest.evidence.some((item) => item.kind === "readme" && item.path === "README.md"));
+    assert.ok(first.snapshot.metadata.immutable.evidence_manifest.evidence.some((item) => item.kind === "license" && item.path === "LICENSE"));
+    assert.equal(first.snapshot.metadata.immutable.license_status.status, "compatible");
+
+    const metadataOnly = await firstCandidate(projectRoot, corexRoot);
+    assert.ok(metadataOnly.conflict_findings.some((finding) => finding.kind === "missing_immutable_source_snapshot"));
+
+    const writtenA = await resolveSourceSnapshot(repo, { projectRoot, client });
+    assert.equal(writtenA.wrote, true);
+    const checkA = await checkSourceSnapshot(repo, { projectRoot });
+    assert.equal(checkA.ok, true);
+
+    const candidateA1 = await firstCandidate(projectRoot, corexRoot);
+    const candidateA2 = await firstCandidate(projectRoot, corexRoot);
+    assert.equal(candidateA1.content_checksum, candidateA2.content_checksum);
+    assert.ok(!candidateA1.conflict_findings.some((finding) => finding.kind === "missing_immutable_source_snapshot"));
+    assert.match(candidateA1.source_snapshot_identity.source_ref, new RegExp(`@${COMMIT_A}$`));
+
+    client.branchSha = COMMIT_B;
+    await resolveSourceSnapshot(repo, { projectRoot, client });
+    const candidateB = await firstCandidate(projectRoot, corexRoot);
+    assert.notEqual(candidateB.content_checksum, candidateA1.content_checksum);
+    assert.match(candidateB.source_snapshot_identity.source_ref, new RegExp(`@${COMMIT_B}$`));
+
+    const snapshotPath = path.join(projectRoot, candidateB.source_snapshot_identity.artifact_ref);
+    const corrupted = JSON.parse(await fs.readFile(snapshotPath, "utf8"));
+    corrupted.metadata.immutable.evidence_manifest.evidence[0].content_sha256 = `sha256:${"0".repeat(64)}`;
+    await fs.writeFile(snapshotPath, stablePrettyStringify(corrupted), "utf8");
+    const corruptedCheck = await checkSourceSnapshot(repo, { projectRoot });
+    assert.equal(corruptedCheck.ok, false);
+    assert.ok(corruptedCheck.blockers.includes("evidence digest does not match evidence manifest"));
+
+    const emptyProject = path.join(root, "empty-vega");
+    const miss = await checkSourceSnapshot(repo, { projectRoot: emptyProject });
+    assert.equal(miss.ok, false);
+    assert.deepEqual(miss.blockers, ["offline cache miss"]);
+
+    const missingEvidence = new FixtureGitHubClient();
+    missingEvidence.files.get(COMMIT_A).delete("LICENSE");
+    await assertRejectsCode(resolveSourceSnapshot(repo, { projectRoot, client: missingEvidence, write: false }), "missing_required_evidence");
+
+    const privateClient = new FixtureGitHubClient();
+    privateClient.private = true;
+    await assertRejectsCode(resolveSourceSnapshot(repo, { projectRoot, client: privateClient, write: false }), "repository_unavailable");
+
+    const truncatedClient = new FixtureGitHubClient();
+    truncatedClient.truncatedTree = true;
+    await assertRejectsCode(resolveSourceSnapshot(repo, { projectRoot, client: truncatedClient, write: false }), "tree_truncated");
+
+    const secretClient = new FixtureGitHubClient();
+    secretClient.files.get(COMMIT_A).set("README.md", "to" + "ken=super-secret-value");
+    await assertRejectsCode(resolveSourceSnapshot(repo, { projectRoot, client: secretClient, write: false }), "secret_evidence");
+
+    const rateLimitedClient = new FixtureGitHubClient();
+    rateLimitedClient.rateLimit = true;
+    await assertRejectsCode(resolveSourceSnapshot(repo, { projectRoot, client: rateLimitedClient, write: false }), "rate_limit_or_forbidden");
+
+    const report = await runResolveSourceSnapshots([
+      "--check",
+      "--repo=yusufkaraaslan/Skill_Seekers",
+      `--project-root=${emptyProject}`,
+    ]);
+    assert.equal(report.check, true);
+    assert.equal(report.failed_count, 1);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error("Source snapshot resolver test failed");
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a deterministic immutable source snapshot resolver for GitHub repos
- bind source snapshots to resolved commit SHA, tree SHA, README/license/manifest evidence digests, metadata digest, and aggregate evidence digest
- make Vega skill candidates use cached immutable snapshots when available and block metadata-only candidates before promotion
- add offline fixture tests for resolver determinism, branch movement, fail-closed paths, cache mismatch, and candidate checksum changes

## Verification
- pnpm install --frozen-lockfile
- npm run test
- npm run test:source-snapshots
- npm run test:skill-candidate-ingestion
- npm run test:corex-contract-export
- npm run test:corex-contract-snapshots
- npm run build
- Core-X: pytest test_vega_skill_contracts.py, test_vega_skill_apply_cli.py, test_vega_skill_transactions.py, test_vega_skill_promotion.py, test_skill_registry_generator.py
- custom Core-X smoke: immutable Vega candidate compiles to an eligible dry-run promotion bundle

## Notes
- data/review source snapshot cache artifacts are ignored and not committed
- live Skill Seekers snapshot resolved unauthenticated and remains local review cache only
- existing Core-X optional VEGA_LAB_ROOT compatibility fixture is metadata-only and should be updated separately if Core-X wants that optional test to run under the new immutable precondition
