### PR TITLE
feat(vega): make repo actions durable

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test:corex-contract-snapshots": "node tests/test-corex-contract-snapshots.js",
     "test:source-snapshots": "node tests/test-source-snapshot-resolver.js",
     "test:skill-candidate-ingestion": "node tests/test-skill-candidate-ingestion.js",
-    "test": "npm run lint && npm run test:data && npm run test:mcp"
+    "test:action-bridge": "node tests/test-action-bridge.js",
+    "test": "npm run lint && npm run test:data && npm run test:mcp && npm run test:action-bridge"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.3",

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Bot, Loader, Send, User as UserIcon, Wrench, X } from "lucide-react";
-import type { Repo } from "../types";
+import type { Repo, VegaActionResult } from "../types";
 import type { VegaLabRoute } from "../lib/orchestrator";
 import {
   buildVegaLabTools,
@@ -9,7 +9,13 @@ import {
   HOUSE_ID,
   routeVegaLabIntent,
 } from "../lib/orchestrator";
-import { formatVegaActionResult, inferActionFromPrompt, runVegaAction } from "../lib/action-bridge";
+import {
+  fetchVegaActionRuns,
+  formatVegaActionResult,
+  inferActionFromPrompt,
+  runVegaAction,
+  workflowStagesForRepo,
+} from "../lib/action-bridge";
 import type { OpenResponsesEvent } from "../lib/openresponses-client";
 import { streamOpenResponses } from "../lib/openresponses-client";
 import { fetchRuntimeModels } from "../lib/runtime-client";
@@ -56,6 +62,8 @@ export function ChatPanel({
   const [toolCalls, setToolCalls] = useState<Record<string, ToolCall>>({});
   const [defaultModel, setDefaultModel] = useState<string | null>(null);
   const [activeRoute, setActiveRoute] = useState<VegaLabRoute | null>(null);
+  const [workflowRuns, setWorkflowRuns] = useState<VegaActionResult[]>([]);
+  const [actionRuntimeState, setActionRuntimeState] = useState<"unknown" | "connected" | "disconnected">("unknown");
   const [runtimeTarget, setRuntimeTarget] = useState(() =>
     resolveRuntimeTarget(loadRuntimeSettings()),
   );
@@ -68,6 +76,24 @@ export function ChatPanel({
   const tools = useMemo(() => buildVegaLabTools(), []);
   const activeMissionTarget = runtimeTarget.mode === "local" ? "mlx" : "codex";
   const repoSessionKey = repo ? `${repo.author}/${repo.name}` : null;
+  const workflowStages = useMemo(() => workflowStagesForRepo(workflowRuns, repo), [repo, workflowRuns]);
+
+  const refreshWorkflowRuns = useCallback(() => {
+    if (!repoSessionKey) {
+      setWorkflowRuns([]);
+      setActionRuntimeState("unknown");
+      return Promise.resolve();
+    }
+    return fetchVegaActionRuns()
+      .then((runs) => {
+        setWorkflowRuns(runs);
+        setActionRuntimeState("connected");
+      })
+      .catch(() => {
+        setWorkflowRuns([]);
+        setActionRuntimeState("disconnected");
+      });
+  }, [repoSessionKey]);
 
   function getWelcomeMessages(currentRepo: Repo): Message[] {
     return [
@@ -111,7 +137,8 @@ export function ChatPanel({
     setToolCalls({});
     setActiveRoute(null);
     setIsLoading(false);
-  }, [isOpen, repo, repoSessionKey]);
+    void refreshWorkflowRuns();
+  }, [isOpen, refreshWorkflowRuns, repo, repoSessionKey]);
 
   useEffect(() => {
     messagesRef.current = messages;
@@ -257,6 +284,7 @@ export function ChatPanel({
       })
         .then((result) => {
           const formatted = formatVegaActionResult(result);
+          setActionRuntimeState("connected");
           setMessages((previous) => {
             const updated = previous.map((message) =>
               message.id === assistantId ? { ...message, content: formatted } : message,
@@ -271,9 +299,11 @@ export function ChatPanel({
               status: "done",
             },
           }));
+          void refreshWorkflowRuns();
           onRunComplete?.();
         })
         .catch((error: Error) => {
+          setActionRuntimeState("disconnected");
           setMessages((previous) => [
             ...previous.map((message) =>
               message.id === assistantId
@@ -328,7 +358,7 @@ export function ChatPanel({
         ]);
       },
     });
-  }, [activeMissionTarget, agentId, defaultModel, input, onRunComplete, repo, runtimeTarget, tools]);
+  }, [activeMissionTarget, agentId, defaultModel, input, onRunComplete, refreshWorkflowRuns, repo, runtimeTarget, tools]);
 
   useEffect(() => {
     if (!isOpen || !prefill) return;
@@ -370,6 +400,24 @@ export function ChatPanel({
         <button className="chip chip-tag" onClick={() => handleSend(`Call generate_repo_ops_kit with target ${activeMissionTarget} and summarize the generated draft artifacts.`)}>Ops Kit</button>
         <button className="chip chip-tag" onClick={() => handleSend("Call update_research_queue with status queued and explain why this repo belongs in the research queue.")}>Queue</button>
         <button className="chip chip-tag" onClick={() => handleSend(`Call generate_repo_mission with target ${activeMissionTarget} and return the mission brief.`)}>Mission</button>
+      </div>
+
+      <div className="orchestrator-workflow">
+        <div className={`orchestrator-runtime ${actionRuntimeState}`}>
+          Action bridge: {actionRuntimeState === "connected" ? "connected" : actionRuntimeState === "disconnected" ? "disconnected" : "checking"}
+        </div>
+        <div className="workflow-stage-grid" aria-label="Vega durable action workflow">
+          {workflowStages.map((stage) => (
+            <div
+              key={stage.id}
+              className={`workflow-stage ${stage.state}`}
+              title={stage.description}
+            >
+              <span className="workflow-stage__dot" />
+              <span className="workflow-stage__label">{stage.label}</span>
+            </div>
+          ))}
+        </div>
       </div>
 
       <div ref={scrollRef} className="orchestrator-messages">

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -9,6 +9,7 @@ import {
   HOUSE_ID,
   routeVegaLabIntent,
 } from "../lib/orchestrator";
+import { formatVegaActionResult, inferActionFromPrompt, runVegaAction } from "../lib/action-bridge";
 import type { OpenResponsesEvent } from "../lib/openresponses-client";
 import { streamOpenResponses } from "../lib/openresponses-client";
 import { fetchRuntimeModels } from "../lib/runtime-client";
@@ -197,6 +198,7 @@ export function ChatPanel({
 
     const route = routeVegaLabIntent(content);
     setActiveRoute(route);
+    const bridgeAction = inferActionFromPrompt(content, activeMissionTarget);
 
     const userMessage: Message = {
       id: Date.now().toString(),
@@ -230,6 +232,67 @@ export function ChatPanel({
     setMessages(nextMessages);
 
     streamRef.current?.abort();
+
+    if (bridgeAction) {
+      const callId = `vega-action-${Date.now()}`;
+      setToolCalls((previous) => ({
+        ...previous,
+        [callId]: {
+          id: callId,
+          name: bridgeAction.actionKind,
+          arguments: JSON.stringify({
+            repo: `${repo.author}/${repo.name}`,
+            parameters: bridgeAction.parameters || {},
+            write: bridgeAction.write === true,
+          }, null, 2),
+          status: "in_progress",
+        },
+      }));
+
+      runVegaAction({
+        repo,
+        actionKind: bridgeAction.actionKind,
+        parameters: bridgeAction.parameters,
+        write: bridgeAction.write,
+      })
+        .then((result) => {
+          const formatted = formatVegaActionResult(result);
+          setMessages((previous) => {
+            const updated = previous.map((message) =>
+              message.id === assistantId ? { ...message, content: formatted } : message,
+            );
+            messagesRef.current = updated;
+            return updated;
+          });
+          setToolCalls((previous) => ({
+            ...previous,
+            [callId]: {
+              ...previous[callId],
+              status: "done",
+            },
+          }));
+          onRunComplete?.();
+        })
+        .catch((error: Error) => {
+          setMessages((previous) => [
+            ...previous.map((message) =>
+              message.id === assistantId
+                ? { ...message, content: `Tooling error: ${error.message}` }
+                : message,
+            ),
+          ]);
+          setToolCalls((previous) => ({
+            ...previous,
+            [callId]: {
+              ...previous[callId],
+              status: "done",
+            },
+          }));
+        })
+        .finally(() => setIsLoading(false));
+      return;
+    }
+
     streamRef.current = streamOpenResponses({
       endpoint: `${runtimeTarget.busUrl}${runtimeTarget.responsesPath}`,
       body: {
@@ -265,7 +328,7 @@ export function ChatPanel({
         ]);
       },
     });
-  }, [agentId, defaultModel, input, onRunComplete, repo, runtimeTarget, tools]);
+  }, [activeMissionTarget, agentId, defaultModel, input, onRunComplete, repo, runtimeTarget, tools]);
 
   useEffect(() => {
     if (!isOpen || !prefill) return;

--- a/src/components/ReadmePanel.tsx
+++ b/src/components/ReadmePanel.tsx
@@ -3,6 +3,8 @@ import { marked } from "marked";
 import DOMPurify from "dompurify";
 import { ExternalLink, Sparkles, Wand2, X } from "lucide-react";
 import type { Repo } from "../types";
+import type { VegaActionKind } from "../types";
+import { formatVegaActionResult, inferActionFromPrompt, runVegaAction } from "../lib/action-bridge";
 import { streamOpenResponses } from "../lib/openresponses-client";
 import { fetchRuntimeModels } from "../lib/runtime-client";
 import type { ActionPreset, VegaLabRoute } from "../lib/orchestrator";
@@ -75,10 +77,61 @@ export function ReadmePanel({
     }
   }, []);
 
-  const runAction = useCallback((prompt: string, title: string) => {
+  const runAction = useCallback((
+    prompt: string,
+    title: string,
+    actionKind?: VegaActionKind,
+    actionParameters?: Record<string, unknown>,
+    write?: boolean,
+  ) => {
     if (!repo) return;
     const actionId = `action-${Date.now()}`;
     const route = routeVegaLabIntent(prompt);
+    const activeMissionTarget = runtimeTarget.mode === "local" ? "mlx" : "codex";
+    const inferredAction = actionKind
+      ? { actionKind, parameters: actionParameters, write }
+      : inferActionFromPrompt(prompt, activeMissionTarget);
+
+    if (inferredAction) {
+      setActiveRoute(route);
+      setOverlayTitle(title);
+      setOverlayContent("Starting typed Vega action...");
+      setOverlayVisible(true);
+      setIsRunning(true);
+
+      const userMessage: ChatMessage = { id: `${actionId}-user`, role: "user", content: prompt };
+      const assistantMessage: ChatMessage = { id: `${actionId}-assistant`, role: "assistant", content: "" };
+      setMessages((previous) => [...previous, userMessage, assistantMessage]);
+
+      runVegaAction({
+        repo,
+        actionKind: inferredAction.actionKind,
+        parameters: inferredAction.parameters,
+        write: inferredAction.write,
+      })
+        .then((result) => {
+          const formatted = formatVegaActionResult(result);
+          setMessages((previous) =>
+            previous.map((message) =>
+              message.id === assistantMessage.id ? { ...message, content: formatted } : message,
+            ),
+          );
+          setOverlayContent(formatted);
+          onHouseDataChanged?.();
+        })
+        .catch((nextError: Error) => {
+          const errorText = `Tooling error: ${nextError.message}`;
+          setMessages((previous) =>
+            previous.map((message) =>
+              message.id === assistantMessage.id ? { ...message, content: errorText } : message,
+            ),
+          );
+          setOverlayContent(errorText);
+        })
+        .finally(() => setIsRunning(false));
+      return;
+    }
+
     const excerpt = rawMarkdown.slice(0, 4000);
     const conversation = [
       {
@@ -252,7 +305,7 @@ export function ReadmePanel({
           <button
             key={action.label}
             className={`action-btn ${action.variant === "primary" ? "primary" : ""}`}
-            onClick={() => runAction(action.prompt, action.title)}
+            onClick={() => runAction(action.prompt, action.title, action.actionKind, action.actionParameters, action.write)}
           >
             {action.variant === "primary" ? <Wand2 size={14} /> : <Sparkles size={14} />} {action.label}
           </button>

--- a/src/css/design-system.css
+++ b/src/css/design-system.css
@@ -1998,6 +1998,95 @@ table.repo-table {
   gap: 8px;
 }
 
+.orchestrator-workflow {
+  padding: 8px 18px 10px;
+  border-bottom: 1px solid var(--card-border);
+}
+
+.orchestrator-runtime {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  margin-bottom: 8px;
+  padding: 4px 8px;
+  border: 1px solid var(--card-border);
+  border-radius: 999px;
+  color: var(--card-muted);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.orchestrator-runtime.connected {
+  border-color: rgba(52, 168, 83, 0.4);
+  color: #1f7a39;
+}
+
+.orchestrator-runtime.disconnected {
+  border-color: rgba(217, 74, 43, 0.45);
+  color: var(--card-accent);
+}
+
+.workflow-stage-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.workflow-stage {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  padding: 6px 8px;
+  border: 1px solid var(--card-border);
+  border-radius: 10px;
+  background: var(--color-surface);
+  color: var(--card-muted);
+  font-size: 0.68rem;
+  font-weight: 800;
+}
+
+.workflow-stage__dot {
+  width: 7px;
+  height: 7px;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  flex: 0 0 auto;
+}
+
+.workflow-stage__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workflow-stage.succeeded {
+  color: #1f7a39;
+  border-color: rgba(52, 168, 83, 0.36);
+}
+
+.workflow-stage.succeeded .workflow-stage__dot,
+.workflow-stage.running .workflow-stage__dot {
+  background: currentColor;
+}
+
+.workflow-stage.running {
+  color: var(--card-ink);
+}
+
+.workflow-stage.failed,
+.workflow-stage.blocked {
+  color: var(--card-accent);
+  border-color: rgba(217, 74, 43, 0.36);
+}
+
+.workflow-stage.locked {
+  opacity: 0.62;
+  background: transparent;
+}
+
 .orchestrator-messages {
   flex: 1;
   overflow-y: auto;

--- a/src/lib/action-bridge.ts
+++ b/src/lib/action-bridge.ts
@@ -8,6 +8,88 @@ export interface RepoActionOptions {
   write?: boolean;
 }
 
+export interface VegaWorkflowStage {
+  id: string;
+  label: string;
+  description: string;
+  actionKind?: VegaActionKind;
+  locked?: boolean;
+}
+
+export interface VegaWorkflowStageState extends VegaWorkflowStage {
+  state: "pending" | "queued" | "running" | "succeeded" | "failed" | "blocked" | "cancelled" | "locked";
+  run?: VegaActionResult;
+}
+
+export const VEGA_WORKFLOW_STAGES: VegaWorkflowStage[] = [
+  {
+    id: "repo.inspect",
+    actionKind: "repo.inspect",
+    label: "Repo inspected",
+    description: "Metadata, signals, extraction, and adoption fit loaded.",
+  },
+  {
+    id: "snapshot.resolve",
+    actionKind: "snapshot.resolve",
+    label: "Source snapshot",
+    description: "Immutable source evidence checked or resolved.",
+  },
+  {
+    id: "candidate.build",
+    actionKind: "candidate.build",
+    label: "Candidate built",
+    description: "Pending skill candidate created from pinned evidence.",
+  },
+  {
+    id: "candidate.validate",
+    actionKind: "candidate.validate",
+    label: "Candidate valid",
+    description: "Candidate schema, checksum, provenance, and safety verified.",
+  },
+  {
+    id: "dossier.generate",
+    actionKind: "dossier.generate",
+    label: "Dossier ready",
+    description: "Internal human approval packet generated.",
+  },
+  {
+    id: "review.queue",
+    actionKind: "review.queue",
+    label: "Research queued",
+    description: "Repository is durable in the review/research queue.",
+  },
+  {
+    id: "review.approve",
+    label: "Human decision",
+    description: "Requires explicit human approval outside this UI flow.",
+    locked: true,
+  },
+  {
+    id: "promotion.propose",
+    label: "Promotion proposal",
+    description: "Core-X capability promotion proposal remains locked.",
+    locked: true,
+  },
+  {
+    id: "corex.dry-run",
+    label: "Core-X dry-run",
+    description: "Registry dry-run must be initiated separately.",
+    locked: true,
+  },
+  {
+    id: "bundle.review",
+    label: "Bundle review",
+    description: "Promotion bundle review remains operator-gated.",
+    locked: true,
+  },
+  {
+    id: "corex.apply",
+    label: "Apply",
+    description: "No apply path is exposed from Vega.",
+    locked: true,
+  },
+];
+
 export async function runVegaAction(options: RepoActionOptions): Promise<VegaActionResult> {
   const body: VegaActionRequest = {
     action_kind: options.actionKind,
@@ -27,6 +109,7 @@ export async function runVegaAction(options: RepoActionOptions): Promise<VegaAct
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      "X-Vega-Action-Origin": "vega-lab-ui",
     },
     body: JSON.stringify(body),
   });
@@ -37,6 +120,51 @@ export async function runVegaAction(options: RepoActionOptions): Promise<VegaAct
     throw new Error(message);
   }
   return payload as VegaActionResult;
+}
+
+export async function fetchVegaActionRuns(): Promise<VegaActionResult[]> {
+  const response = await fetch("/api/vega/actions/runs", {
+    method: "GET",
+    headers: {
+      "Accept": "application/json",
+    },
+  });
+
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    const message = payload?.error?.message || payload?.message || `HTTP ${response.status}`;
+    throw new Error(message);
+  }
+  return (payload?.runs || []) as VegaActionResult[];
+}
+
+function repoNwo(repo?: Repo | null): string {
+  return repo ? `${repo.author}/${repo.name}`.toLowerCase() : "";
+}
+
+function runMatchesRepo(run: VegaActionResult, repo?: Repo | null): boolean {
+  const target = repoNwo(repo);
+  if (!target) return false;
+  return String(run.repo?.nwo || "").toLowerCase() === target;
+}
+
+export function workflowStagesForRepo(runs: VegaActionResult[], repo?: Repo | null): VegaWorkflowStageState[] {
+  return VEGA_WORKFLOW_STAGES.map((stage) => {
+    if (stage.locked || !stage.actionKind) {
+      return {
+        ...stage,
+        state: "locked" as const,
+      };
+    }
+    const run = runs.find((candidateRun) =>
+      candidateRun.action_kind === stage.actionKind && runMatchesRepo(candidateRun, repo),
+    );
+    return {
+      ...stage,
+      state: run?.status || "pending",
+      run,
+    };
+  });
 }
 
 function summarizeValue(value: unknown): string {
@@ -84,12 +212,29 @@ export function formatVegaActionResult(result: VegaActionResult): string {
   const lines = [
     "**Direct Answer**",
     result.status === "succeeded"
-      ? `Vega action \`${result.action_kind}\` completed and remains \`${result.review_state}\` / \`${result.visibility}\`.`
-      : `Vega action \`${result.action_kind}\` failed: ${result.error?.message || "unknown error"}.`,
+      ? `Vega action \`${result.action_kind}\` completed as run \`${result.run_id}\` and remains \`${result.review_state}\` / \`${result.visibility}\`.`
+      : `Vega action \`${result.action_kind}\` is \`${result.status}\`: ${result.error?.message || "unknown error"}.`,
+    "",
+    "**Receipt**",
+    `- Run: \`${result.run_id}\``,
+    `- Action: \`${result.action_id}\``,
+    `- Requested: ${result.requested_at}`,
+    `- Input digest: \`${result.input_digest}\``,
     "",
     "**Progress**",
     ...result.steps.map((step) => `- ${step.status}: ${step.label}${step.detail ? ` — ${step.detail}` : ""}`),
   ];
+
+  if (result.warnings.length > 0) {
+    lines.push("", "**Warnings**");
+    lines.push(...result.warnings.map((warning) => `- ${warning}`));
+  }
+
+  if (result.error) {
+    lines.push("", "**Error**");
+    lines.push(`- Code: \`${result.error.code}\``);
+    lines.push(`- Retryable: ${result.error.retryable ? "yes" : "no"}`);
+  }
 
   if (result.artifacts.length > 0) {
     lines.push("", "**Artifacts**");
@@ -101,8 +246,12 @@ export function formatVegaActionResult(result: VegaActionResult): string {
   }
 
   lines.push("", "**Next Actions**");
-  lines.push("- Review the internal artifact before promotion or publication.");
-  lines.push("- If this is a skill candidate, validate it and generate a dossier before requesting approval.");
+  if (result.status === "blocked") {
+    lines.push("- Resolve the blocker before retrying this action.");
+  } else {
+    lines.push("- Review the internal artifact before promotion or publication.");
+    lines.push("- If this is a skill candidate, validate it and generate a dossier before requesting approval.");
+  }
 
   return lines.join("\n");
 }

--- a/src/lib/action-bridge.ts
+++ b/src/lib/action-bridge.ts
@@ -1,0 +1,190 @@
+import type { Repo, VegaActionKind, VegaActionRequest, VegaActionResult } from "../types";
+
+export interface RepoActionOptions {
+  actionKind: VegaActionKind;
+  repo?: Repo | null;
+  candidateId?: string;
+  parameters?: Record<string, unknown>;
+  write?: boolean;
+}
+
+export async function runVegaAction(options: RepoActionOptions): Promise<VegaActionResult> {
+  const body: VegaActionRequest = {
+    action_kind: options.actionKind,
+    candidate_id: options.candidateId,
+    parameters: options.parameters || {},
+    write: options.write,
+    repo: options.repo
+      ? {
+          name: options.repo.name,
+          author: options.repo.author,
+          nwo: `${options.repo.author}/${options.repo.name}`,
+        }
+      : undefined,
+  };
+
+  const response = await fetch("/api/vega/actions/run", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    const message = payload?.error?.message || payload?.message || `HTTP ${response.status}`;
+    throw new Error(message);
+  }
+  return payload as VegaActionResult;
+}
+
+function summarizeValue(value: unknown): string {
+  if (!value || typeof value !== "object") return String(value ?? "");
+
+  const record = value as Record<string, unknown>;
+  if (typeof record.summary === "string") return record.summary;
+  if (typeof record.mission === "string") return record.mission;
+  if (record.adoption_fit && typeof record.adoption_fit === "object") {
+    const fit = record.adoption_fit as { kind?: string; score?: number; reasons?: string[] };
+    return [
+      `Adoption kind: ${fit.kind || "unknown"}`,
+      typeof fit.score === "number" ? `Score: ${fit.score}` : null,
+      ...(fit.reasons || []).slice(0, 4),
+    ].filter(Boolean).join("\n");
+  }
+  if (Array.isArray(record.artifacts)) {
+    return record.artifacts
+      .map((artifact) => {
+        const next = artifact as { kind?: string; title?: string; body?: string };
+        return [`### ${next.title || next.kind || "Artifact"}`, next.body || ""].join("\n");
+      })
+      .join("\n\n");
+  }
+  if (record.candidate && typeof record.candidate === "object") {
+    const candidate = record.candidate as {
+      candidate_id?: string;
+      suggested_skill_id?: string;
+      evidence_summary?: string;
+      review_status?: string;
+    };
+    return [
+      `Candidate: ${candidate.candidate_id}`,
+      `Suggested skill: ${candidate.suggested_skill_id}`,
+      `Review: ${candidate.review_status || "pending"}`,
+      "",
+      candidate.evidence_summary || "",
+    ].join("\n");
+  }
+
+  return `\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\``;
+}
+
+export function formatVegaActionResult(result: VegaActionResult): string {
+  const lines = [
+    "**Direct Answer**",
+    result.status === "succeeded"
+      ? `Vega action \`${result.action_kind}\` completed and remains \`${result.review_state}\` / \`${result.visibility}\`.`
+      : `Vega action \`${result.action_kind}\` failed: ${result.error?.message || "unknown error"}.`,
+    "",
+    "**Progress**",
+    ...result.steps.map((step) => `- ${step.status}: ${step.label}${step.detail ? ` — ${step.detail}` : ""}`),
+  ];
+
+  if (result.artifacts.length > 0) {
+    lines.push("", "**Artifacts**");
+    lines.push(...result.artifacts.map((artifact) => `- ${artifact.kind}: ${artifact.path || artifact.title || "in-memory"}`));
+  }
+
+  if (result.result) {
+    lines.push("", "**Result**", summarizeValue(result.result));
+  }
+
+  lines.push("", "**Next Actions**");
+  lines.push("- Review the internal artifact before promotion or publication.");
+  lines.push("- If this is a skill candidate, validate it and generate a dossier before requesting approval.");
+
+  return lines.join("\n");
+}
+
+export function inferActionFromPrompt(prompt: string, activeMissionTarget: "codex" | "claude" | "mlx" = "mlx"): {
+  actionKind: VegaActionKind;
+  parameters?: Record<string, unknown>;
+  write?: boolean;
+} | null {
+  const text = prompt.toLowerCase();
+
+  if (/\b(queue|research queue|queued|research)\b/.test(text) && /\bupdate_research_queue|queue|research\b/.test(text)) {
+    return {
+      actionKind: "review.queue",
+      parameters: {
+        status: "queued",
+        priority: "normal",
+        notes: "Queued from Vega UI action for research, adoption fit, and skill evidence review.",
+      },
+      write: true,
+    };
+  }
+
+  if (/\b(source snapshot|snapshot\.resolve|immutable snapshot)\b/.test(text)) {
+    return {
+      actionKind: "snapshot.resolve",
+      write: /\b(write|resolve|cache)\b/.test(text),
+    };
+  }
+
+  if (/\b(skill candidate|candidate\.build)\b/.test(text)) {
+    return {
+      actionKind: "candidate.build",
+      write: true,
+    };
+  }
+
+  if (/\b(validate candidate|candidate\.validate)\b/.test(text)) {
+    return {
+      actionKind: "candidate.validate",
+      write: false,
+    };
+  }
+
+  if (/\b(dossier|approval packet|human approval packet)\b/.test(text)) {
+    return {
+      actionKind: "dossier.generate",
+      write: true,
+    };
+  }
+
+  if (/\b(ops kit|readme draft|agents draft|deployment plan|test plan)\b/.test(text)) {
+    let artifactKind = null;
+    if (text.includes("readme draft")) artifactKind = "readme";
+    else if (text.includes("agents draft")) artifactKind = "agents";
+    else if (text.includes("deployment plan")) artifactKind = "deployment";
+    else if (text.includes("test plan")) artifactKind = "testing";
+    return {
+      actionKind: "ops-kit.generate",
+      parameters: {
+        target: activeMissionTarget,
+        ...(artifactKind ? { artifactKind } : {}),
+      },
+      write: false,
+    };
+  }
+
+  if (/\b(mission|generate_repo_mission)\b/.test(text)) {
+    const target = text.includes("claude") ? "claude" : text.includes("codex") ? "codex" : activeMissionTarget;
+    return {
+      actionKind: "mission.generate",
+      parameters: { target },
+      write: false,
+    };
+  }
+
+  if (/\b(brief|adoption fit|repo inspect|get_repo_details|extract_repo_skills)\b/.test(text)) {
+    return {
+      actionKind: "repo.inspect",
+      write: false,
+    };
+  }
+
+  return null;
+}

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -1,4 +1,4 @@
-import type { Repo } from "../types";
+import type { Repo, VegaActionKind } from "../types";
 
 export const VEGA_LAB_HOUSE_ID = "vega-lab";
 export const LEGACY_HOUSE_ID = "git-stars";
@@ -25,6 +25,9 @@ export interface ActionPreset {
   prompt: string;
   title: string;
   variant?: "primary" | "default";
+  actionKind?: VegaActionKind;
+  actionParameters?: Record<string, unknown>;
+  write?: boolean;
 }
 
 const ROUTES: Array<{ pattern: RegExp; route: VegaLabRoute }> = [
@@ -650,46 +653,64 @@ const GENERAL_ACTIONS: ActionPreset[] = [
     title: "Ops kit",
     prompt: "Call generate_repo_ops_kit with target mlx and summarize the README, AGENTS, maintenance, deployment, testing, and action-item artifacts.",
     variant: "primary",
+    actionKind: "ops-kit.generate",
+    actionParameters: { target: "mlx" },
   },
   {
     label: "README draft",
     title: "README draft",
     prompt: "Call generate_repo_ops_kit with target mlx and return only the README artifact with its evidence.",
+    actionKind: "ops-kit.generate",
+    actionParameters: { target: "mlx", artifactKind: "readme" },
   },
   {
     label: "AGENTS draft",
     title: "AGENTS draft",
     prompt: "Call generate_repo_ops_kit with target mlx and return only the AGENTS artifact with operating rules and commands.",
+    actionKind: "ops-kit.generate",
+    actionParameters: { target: "mlx", artifactKind: "agents" },
   },
   {
     label: "Deployment plan",
     title: "Deployment plan",
     prompt: "Call generate_repo_ops_kit with target mlx and return the deployment artifact with known evidence and missing checks.",
+    actionKind: "ops-kit.generate",
+    actionParameters: { target: "mlx", artifactKind: "deployment" },
   },
   {
     label: "Test plan",
     title: "Test plan",
     prompt: "Call generate_repo_ops_kit with target mlx and return the testing artifact with verification commands or gaps.",
+    actionKind: "ops-kit.generate",
+    actionParameters: { target: "mlx", artifactKind: "testing" },
   },
   {
     label: "SKILL candidate",
     title: "SKILL candidate",
     prompt: "Call generate_skill_candidate_from_ocr_evidence with writeArtifact true and return the internal pending SKILL candidate, evidence refs, and limitations. Do not publish it.",
+    actionKind: "candidate.build",
+    write: true,
   },
   {
     label: "MLX mission",
     title: "MLX mission",
     prompt: "Call generate_repo_mission with target mlx and return the resulting local MLX mission brief.",
+    actionKind: "mission.generate",
+    actionParameters: { target: "mlx" },
   },
   {
     label: "Codex mission",
     title: "Codex mission",
     prompt: "Call generate_repo_mission with target codex and return the resulting mission brief.",
+    actionKind: "mission.generate",
+    actionParameters: { target: "codex" },
   },
   {
     label: "Claude mission",
     title: "Claude mission",
     prompt: "Call generate_repo_mission with target claude and return the resulting mission brief.",
+    actionKind: "mission.generate",
+    actionParameters: { target: "claude" },
   },
 ];
 
@@ -699,46 +720,64 @@ const MINE_ACTIONS: ActionPreset[] = [
     title: "Ops kit",
     prompt: "Call generate_repo_ops_kit with target mlx and summarize the README, AGENTS, maintenance, deployment, testing, and action-item artifacts for this owned repo.",
     variant: "primary",
+    actionKind: "ops-kit.generate",
+    actionParameters: { target: "mlx" },
   },
   {
     label: "README draft",
     title: "README draft",
     prompt: "Call generate_repo_ops_kit with target mlx and return only the README artifact with its evidence.",
+    actionKind: "ops-kit.generate",
+    actionParameters: { target: "mlx", artifactKind: "readme" },
   },
   {
     label: "AGENTS draft",
     title: "AGENTS draft",
     prompt: "Call generate_repo_ops_kit with target mlx and return only the AGENTS artifact with operating rules and commands.",
+    actionKind: "ops-kit.generate",
+    actionParameters: { target: "mlx", artifactKind: "agents" },
   },
   {
     label: "Deployment plan",
     title: "Deployment plan",
     prompt: "Call generate_repo_ops_kit with target mlx and return the deployment artifact with known evidence and missing checks.",
+    actionKind: "ops-kit.generate",
+    actionParameters: { target: "mlx", artifactKind: "deployment" },
   },
   {
     label: "Test plan",
     title: "Test plan",
     prompt: "Call generate_repo_ops_kit with target mlx and return the testing artifact with verification commands or gaps.",
+    actionKind: "ops-kit.generate",
+    actionParameters: { target: "mlx", artifactKind: "testing" },
   },
   {
     label: "SKILL candidate",
     title: "SKILL candidate",
     prompt: "Call generate_skill_candidate_from_ocr_evidence with writeArtifact true and return the internal pending SKILL candidate, evidence refs, and limitations. Do not publish it.",
+    actionKind: "candidate.build",
+    write: true,
   },
   {
     label: "MLX mission",
     title: "MLX mission",
     prompt: "Call generate_repo_mission with target mlx and return the resulting local MLX mission brief.",
+    actionKind: "mission.generate",
+    actionParameters: { target: "mlx" },
   },
   {
     label: "Codex mission",
     title: "Codex mission",
     prompt: "Call generate_repo_mission with target codex and return the resulting mission brief.",
+    actionKind: "mission.generate",
+    actionParameters: { target: "codex" },
   },
   {
     label: "Claude mission",
     title: "Claude mission",
     prompt: "Call generate_repo_mission with target claude and return the resulting mission brief.",
+    actionKind: "mission.generate",
+    actionParameters: { target: "claude" },
   },
 ];
 

--- a/src/server/action-bridge.js
+++ b/src/server/action-bridge.js
@@ -1,0 +1,622 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  buildMissionBriefForTarget,
+  findRepoInspection,
+  findSkillExtraction,
+  generateDerivedHouseData,
+  generateRepoOpsKit,
+  loadHouseDatasets,
+  resolveRepoRecord,
+  updateResearchQueue,
+} from "./house-model.js";
+import {
+  buildPromotionProposal,
+  buildSkillCandidateIngestion,
+  getSkillCandidate,
+  validateSkillCandidate,
+} from "../../scripts/build-skill-candidates.js";
+import {
+  checkSourceSnapshot,
+  resolveSourceSnapshot,
+  slug,
+  stablePrettyStringify,
+} from "../../scripts/source-snapshot-resolver.js";
+
+const ACTION_SCHEMA_VERSION = "vega.action-result.v1";
+const REVIEW_STATE = "pending";
+const VISIBILITY = "internal";
+const ACTION_KINDS = new Set([
+  "repo.inspect",
+  "snapshot.resolve",
+  "candidate.build",
+  "candidate.validate",
+  "dossier.generate",
+  "review.queue",
+  "ops-kit.generate",
+  "mission.generate",
+]);
+
+function now() {
+  return new Date().toISOString();
+}
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function nwoFromRepo(repo) {
+  if (!repo) return "";
+  if (repo.nwo) return String(repo.nwo);
+  return [repo.author, repo.name].filter(Boolean).join("/");
+}
+
+function normalizeRepoInput(repo = {}) {
+  const nwo = nwoFromRepo(repo);
+  const [authorFromNwo, nameFromNwo] = nwo.split("/");
+  return {
+    name: repo.name || nameFromNwo,
+    author: repo.author || authorFromNwo,
+    nwo,
+  };
+}
+
+function normalizeRequest(request = {}) {
+  const actionKind = String(request.action_kind || "");
+  if (!ACTION_KINDS.has(actionKind)) {
+    throw Object.assign(new Error(`Unsupported Vega action kind: ${actionKind || "missing"}`), {
+      code: "unsupported_action_kind",
+      retryable: false,
+    });
+  }
+  return {
+    action_kind: actionKind,
+    repo: normalizeRepoInput(request.repo || {}),
+    candidate_id: request.candidate_id || request.parameters?.candidate_id || null,
+    parameters: request.parameters && typeof request.parameters === "object" ? request.parameters : {},
+    write: request.write === true,
+  };
+}
+
+function actionId(request) {
+  const target = request.candidate_id || request.repo?.nwo || `${request.repo?.author || ""}/${request.repo?.name || ""}`;
+  return `vega-action-${slug(`${request.action_kind}-${target || "unknown"}`)}-${Date.now()}`;
+}
+
+function relativeToRoot(root, filePath) {
+  return path.relative(root, filePath).replaceAll(path.sep, "/");
+}
+
+function reviewRoot(root) {
+  return path.join(root, "data", "review");
+}
+
+function safeReviewPath(root, ...segments) {
+  const base = reviewRoot(root);
+  const target = path.resolve(base, ...segments);
+  if (!target.startsWith(path.resolve(base) + path.sep) && target !== path.resolve(base)) {
+    throw Object.assign(new Error("Refusing to write outside data/review"), {
+      code: "unsafe_review_path",
+      retryable: false,
+    });
+  }
+  return target;
+}
+
+async function writeJson(filePath, value) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+async function readJson(filePath, fallback = null) {
+  try {
+    return JSON.parse(await fs.readFile(filePath, "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") return fallback;
+    throw error;
+  }
+}
+
+async function writeText(filePath, value) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, value, "utf8");
+}
+
+function createStep(id, label) {
+  const started = now();
+  return {
+    id,
+    label,
+    status: "running",
+    started_at: started,
+  };
+}
+
+function finishStep(step, detail = "") {
+  step.status = "succeeded";
+  step.completed_at = now();
+  if (detail) step.detail = detail;
+  return step;
+}
+
+function failStep(step, detail = "") {
+  step.status = "failed";
+  step.completed_at = now();
+  if (detail) step.detail = detail;
+  return step;
+}
+
+async function loadContext(root) {
+  const datasets = await loadHouseDatasets(root);
+  const derived = await generateDerivedHouseData(root, datasets);
+  return {
+    datasets,
+    derived,
+    repos: [...datasets.myRepos, ...datasets.starredRepos],
+  };
+}
+
+function resolveRepoOrThrow(request, context) {
+  const repo = resolveRepoRecord(request.repo, {
+    starredRepos: context.datasets.starredRepos,
+    myRepos: context.datasets.myRepos,
+  });
+  if (!repo) {
+    throw Object.assign(new Error(`Repository not found: ${request.repo.nwo || request.repo.name}`), {
+      code: "repo_not_found",
+      retryable: false,
+    });
+  }
+  return repo;
+}
+
+function actionRepo(repo) {
+  return {
+    nwo: nwoFromRepo(repo),
+    name: repo.name,
+    author: repo.author,
+  };
+}
+
+async function persistRun(root, run) {
+  const filePath = safeReviewPath(root, "action-runs", `${slug(run.action_id)}.json`);
+  await writeJson(filePath, run);
+  run.artifacts.push({
+    kind: "action-run",
+    path: relativeToRoot(root, filePath),
+    checksum: `sha256:${sha256(JSON.stringify(run))}`,
+  });
+}
+
+async function runRepoInspect(root, request, run) {
+  const step = createStep("repo.inspect", "Load repo metadata, signals, skill extraction, and inspection");
+  run.steps.push(step);
+  const context = await loadContext(root);
+  const repo = resolveRepoOrThrow(request, context);
+  const nwo = nwoFromRepo(repo);
+  const signal = context.derived.repoSignals.find((item) => item.nwo?.toLowerCase() === nwo.toLowerCase()) || null;
+  const extraction = findSkillExtraction(context.derived.skillExtractions, nwo);
+  const inspection = findRepoInspection(context.derived.repoInspections, nwo);
+  run.repo = actionRepo(repo);
+  run.result = {
+    repo,
+    signal,
+    extraction,
+    inspection,
+    adoption_fit: {
+      kind: signal?.adoptionKind || extraction?.adoptionKind || "ignore",
+      score: signal?.adoptionScore ?? null,
+      reasons: signal?.reasons || [],
+      first_action: "Queue for research, resolve immutable source snapshot, then build a pending skill candidate if evidence is strong.",
+    },
+  };
+  finishStep(step, `Loaded ${nwo}`);
+}
+
+async function runReviewQueue(root, request, run) {
+  const context = await loadContext(root);
+  const repo = resolveRepoOrThrow(request, context);
+  const nwo = nwoFromRepo(repo);
+  const step = createStep("review.queue", "Persist repository in the research queue");
+  run.steps.push(step);
+  const item = await updateResearchQueue(root, {
+    nwo,
+    status: String(request.parameters.status || "queued"),
+    notes: String(request.parameters.notes || "Queued from Vega action bridge."),
+    priority: String(request.parameters.priority || "normal"),
+  });
+  const signal = context.derived.repoSignals.find((entry) => entry.nwo?.toLowerCase() === nwo.toLowerCase()) || null;
+  const extraction = findSkillExtraction(context.derived.skillExtractions, nwo);
+  run.repo = actionRepo(repo);
+  run.result = {
+    item,
+    signal,
+    extraction,
+    adoption_fit: {
+      kind: signal?.adoptionKind || extraction?.adoptionKind || "ignore",
+      score: signal?.adoptionScore ?? null,
+      reasons: signal?.reasons || [],
+    },
+    durable_state: "data/research-queue.json",
+  };
+  finishStep(step, `Queued ${nwo}`);
+}
+
+async function runOpsKit(root, request, run) {
+  const context = await loadContext(root);
+  const repo = resolveRepoOrThrow(request, context);
+  const step = createStep("ops-kit.generate", "Generate draft-only repo ops kit");
+  run.steps.push(step);
+  const kit = await generateRepoOpsKit(root, {
+    name: repo.name,
+    author: repo.author,
+    target: request.parameters.target || "mlx",
+  });
+  run.repo = actionRepo(repo);
+  const artifactKind = request.parameters.artifactKind || request.parameters.artifact_kind || null;
+  run.result = artifactKind
+    ? {
+        ...kit,
+        artifacts: kit.artifacts.filter((artifact) => artifact.kind === artifactKind),
+      }
+    : kit;
+  finishStep(step, `Generated ${kit.artifacts.length} draft artifacts`);
+}
+
+async function runMission(root, request, run) {
+  const context = await loadContext(root);
+  const repo = resolveRepoOrThrow(request, context);
+  const nwo = nwoFromRepo(repo);
+  const extraction = findSkillExtraction(context.derived.skillExtractions, nwo);
+  if (!extraction) {
+    throw Object.assign(new Error(`No skill extraction exists for ${nwo}`), {
+      code: "missing_skill_extraction",
+      retryable: false,
+    });
+  }
+  const step = createStep("mission.generate", "Generate model-targeted mission brief");
+  run.steps.push(step);
+  const target = request.parameters.target || "mlx";
+  run.repo = actionRepo(repo);
+  run.result = {
+    target,
+    mission: buildMissionBriefForTarget(extraction, target),
+    extraction,
+  };
+  finishStep(step, `Generated ${target} mission`);
+}
+
+async function runSnapshot(root, request, run) {
+  const context = await loadContext(root);
+  const repo = resolveRepoOrThrow(request, context);
+  const step = createStep("snapshot.resolve", request.write ? "Resolve and cache immutable source snapshot" : "Check cached immutable source snapshot");
+  run.steps.push(step);
+  run.repo = actionRepo(repo);
+  const result = request.write
+    ? await resolveSourceSnapshot(repo, { projectRoot: root, ref: request.parameters.ref || null, write: true })
+    : await checkSourceSnapshot(repo, { projectRoot: root });
+  run.result = result.snapshot
+    ? {
+        ok: true,
+        cache_hit: result.cache_hit,
+        wrote: result.wrote,
+        snapshot_id: result.snapshot.id,
+        artifact_ref: result.snapshot.artifact_ref,
+        commit: result.snapshot.metadata?.immutable?.resolved_commit_sha,
+        tree: result.snapshot.metadata?.immutable?.resolved_tree_sha,
+        evidence_digest: result.snapshot.metadata?.immutable?.evidence_digest,
+      }
+    : result;
+  if (result.snapshot?.artifact_ref) {
+    run.artifacts.push({ kind: "source-snapshot", path: result.snapshot.artifact_ref });
+  }
+  finishStep(step, result.snapshot ? `Snapshot ${result.snapshot.id}` : `Snapshot check ${result.ok ? "ok" : "blocked"}`);
+}
+
+async function findCandidateForRequest(root, request) {
+  const candidateId = request.candidate_id;
+  if (candidateId) {
+    return getSkillCandidate(candidateId, {
+      projectRoot: root,
+      limit: Number(request.parameters.limit || 250),
+      all: true,
+    });
+  }
+
+  const nwo = request.repo?.nwo || [request.repo?.author, request.repo?.name].filter(Boolean).join("/");
+  const result = await buildSkillCandidateIngestion({
+    projectRoot: root,
+    limit: Number(request.parameters.limit || 250),
+    all: true,
+    dryRun: true,
+  });
+  return result.candidates.find((candidate) => candidate.source_repository?.nwo?.toLowerCase() === nwo.toLowerCase()) || null;
+}
+
+async function writeCandidateAndProposal(root, candidate, run) {
+  const safeId = slug(candidate.candidate_id);
+  const candidatePath = safeReviewPath(root, "skill-candidates", `${safeId}.json`);
+  await writeJson(candidatePath, candidate);
+  run.artifacts.push({
+    kind: "skill-candidate",
+    path: relativeToRoot(root, candidatePath),
+    checksum: candidate.content_checksum,
+  });
+
+  const proposal = buildPromotionProposal(candidate, {
+    reviewArtifactRef: relativeToRoot(root, candidatePath),
+  });
+  const proposalPath = safeReviewPath(root, "capability-promotions", `${safeId}.json`);
+  await writeJson(proposalPath, proposal);
+  run.artifacts.push({
+    kind: "capability-promotion-proposal",
+    path: relativeToRoot(root, proposalPath),
+    checksum: `sha256:${sha256(JSON.stringify(proposal))}`,
+  });
+  return proposal;
+}
+
+async function runCandidateBuild(root, request, run) {
+  const step = createStep("candidate.build", "Build deterministic review-gated skill candidate");
+  run.steps.push(step);
+  const candidate = await findCandidateForRequest(root, request);
+  if (!candidate) {
+    throw Object.assign(new Error("No skill candidate matched the selected repository or candidate id."), {
+      code: "candidate_not_found",
+      retryable: false,
+    });
+  }
+  run.repo = {
+    nwo: candidate.source_repository.nwo,
+  };
+  run.candidate_id = candidate.candidate_id;
+  const validation = validateSkillCandidate(candidate);
+  let proposal = buildPromotionProposal(candidate);
+  if (request.write !== false) {
+    proposal = await writeCandidateAndProposal(root, candidate, run);
+  }
+  run.result = {
+    candidate,
+    validation,
+    proposal,
+    wrote: request.write !== false,
+  };
+  finishStep(step, `${candidate.candidate_id} (${validation.valid ? "valid" : "blocked"})`);
+}
+
+async function runCandidateValidate(root, request, run) {
+  const step = createStep("candidate.validate", "Validate candidate schema, checksum, provenance, and safety findings");
+  run.steps.push(step);
+  const candidate = await findCandidateForRequest(root, request);
+  if (!candidate) {
+    throw Object.assign(new Error("No skill candidate matched the selected repository or candidate id."), {
+      code: "candidate_not_found",
+      retryable: false,
+    });
+  }
+  run.repo = {
+    nwo: candidate.source_repository.nwo,
+  };
+  run.candidate_id = candidate.candidate_id;
+  run.result = {
+    candidate,
+    validation: validateSkillCandidate(candidate),
+  };
+  finishStep(step, candidate.candidate_id);
+}
+
+async function checksumWrittenFiles(files) {
+  const checksums = {};
+  for (const filePath of files) {
+    checksums[path.basename(filePath)] = `sha256:${sha256(await fs.readFile(filePath, "utf8"))}`;
+  }
+  return checksums;
+}
+
+async function runDossier(root, request, run) {
+  const step = createStep("dossier.generate", "Generate complete internal human approval packet");
+  run.steps.push(step);
+  const candidate = await findCandidateForRequest(root, request);
+  if (!candidate) {
+    throw Object.assign(new Error("No skill candidate matched the selected repository or candidate id."), {
+      code: "candidate_not_found",
+      retryable: false,
+    });
+  }
+
+  const validation = validateSkillCandidate(candidate);
+  const proposal = buildPromotionProposal(candidate);
+  const safeId = slug(candidate.candidate_id);
+  const packetDir = safeReviewPath(root, "approval-packets", safeId);
+  const snapshot = candidate.source_snapshot_identity?.artifact_ref
+    ? await readJson(path.join(root, candidate.source_snapshot_identity.artifact_ref), null)
+    : null;
+
+  const files = [
+    ["00-DECISION-SUMMARY.md", [
+      `# Decision Summary: ${candidate.name}`,
+      "",
+      `- Candidate: ${candidate.candidate_id}`,
+      `- Suggested skill: ${candidate.suggested_skill_id}`,
+      `- Review state: pending`,
+      `- Visibility: internal`,
+      `- Validation: ${validation.valid ? "valid" : "blocked"}`,
+      "",
+      "No approval is granted by this packet. It exists for human review only.",
+      "",
+    ].join("\n")],
+    ["01-candidate.json", stablePrettyStringify(candidate)],
+    ["02-validation.json", stablePrettyStringify(validation)],
+    ["03-promotion-proposal.json", stablePrettyStringify(proposal)],
+    ["04-source-snapshot.json", stablePrettyStringify(snapshot || { missing: candidate.source_snapshot_identity?.artifact_ref || null })],
+    ["05-evidence.md", [
+      `# Evidence: ${candidate.name}`,
+      "",
+      candidate.evidence_summary,
+      "",
+      "## Provenance",
+      ...candidate.provenance_references.map((ref) => `- ${ref}`),
+      "",
+    ].join("\n")],
+    ["06-risks-and-conflicts.md", [
+      `# Risks and Conflicts: ${candidate.name}`,
+      "",
+      "## Conflicts",
+      ...(candidate.conflict_findings.length ? candidate.conflict_findings.map((finding) => `- ${finding.severity}: ${finding.summary}`) : ["- None reported."]),
+      "",
+      "## Risks",
+      ...(candidate.risk_findings.length ? candidate.risk_findings.map((finding) => `- ${finding.severity}: ${finding.summary}`) : ["- None reported."]),
+      "",
+    ].join("\n")],
+    ["07-duplicate-analysis.md", [
+      `# Duplicate Analysis: ${candidate.name}`,
+      "",
+      ...(candidate.duplicate_matches.length ? candidate.duplicate_matches.map((match) => `- ${match.kind}: ${match.target} (${match.confidence})`) : ["- No duplicate matches reported."]),
+      "",
+    ].join("\n")],
+    ["08-license-review.md", [
+      `# License Review: ${candidate.name}`,
+      "",
+      `- Status: ${candidate.license_status.status}`,
+      `- Identifier: ${candidate.license_status.identifier || "unknown"}`,
+      ...(candidate.license_status.notes || []).map((note) => `- ${note}`),
+      "",
+    ].join("\n")],
+    ["09-operator-checklist.md", [
+      `# Operator Checklist: ${candidate.name}`,
+      "",
+      "- [ ] Confirm source snapshot is immutable and current.",
+      "- [ ] Confirm license compatibility.",
+      "- [ ] Confirm duplicate/conflict findings are acceptable.",
+      "- [ ] Confirm proposed Core-X lane and scope.",
+      "- [ ] Approve separately before any Core-X promotion transaction.",
+      "",
+    ].join("\n")],
+    ["10-reproduction.md", [
+      `# Reproduction: ${candidate.name}`,
+      "",
+      "```bash",
+      "npm run resolve:source-snapshots -- --check --repo " + candidate.source_repository.nwo,
+      "npm run build:skill-candidates -- --dry-run --all",
+      "```",
+      "",
+    ].join("\n")],
+  ];
+
+  const written = [];
+  for (const [name, content] of files) {
+    const filePath = path.join(packetDir, name);
+    await writeText(filePath, content);
+    written.push(filePath);
+  }
+  const checksums = await checksumWrittenFiles(written);
+  const checksumPath = path.join(packetDir, "11-checksums.json");
+  await writeJson(checksumPath, {
+    schema_version: "vega.approval-packet-checksums.v1",
+    candidate_id: candidate.candidate_id,
+    candidate_checksum: candidate.content_checksum,
+    files: checksums,
+  });
+  written.push(checksumPath);
+
+  run.repo = {
+    nwo: candidate.source_repository.nwo,
+  };
+  run.candidate_id = candidate.candidate_id;
+  run.result = {
+    candidate_id: candidate.candidate_id,
+    validation,
+    packet_path: relativeToRoot(root, packetDir),
+    file_count: written.length,
+  };
+  run.artifacts.push(...written.map((filePath) => ({
+    kind: "approval-packet-file",
+    path: relativeToRoot(root, filePath),
+  })));
+  finishStep(step, `Wrote ${written.length} packet files`);
+}
+
+export async function executeVegaAction(rootDir, rawRequest = {}) {
+  const root = path.resolve(rootDir);
+  const request = normalizeRequest(rawRequest);
+  const started = now();
+  const run = {
+    schema_version: ACTION_SCHEMA_VERSION,
+    action_id: actionId(request),
+    action_kind: request.action_kind,
+    status: "running",
+    review_state: REVIEW_STATE,
+    visibility: VISIBILITY,
+    started_at: started,
+    completed_at: started,
+    steps: [],
+    artifacts: [],
+  };
+
+  try {
+    switch (request.action_kind) {
+      case "repo.inspect":
+        await runRepoInspect(root, request, run);
+        break;
+      case "review.queue":
+        await runReviewQueue(root, request, run);
+        break;
+      case "ops-kit.generate":
+        await runOpsKit(root, request, run);
+        break;
+      case "mission.generate":
+        await runMission(root, request, run);
+        break;
+      case "snapshot.resolve":
+        await runSnapshot(root, request, run);
+        break;
+      case "candidate.build":
+        await runCandidateBuild(root, request, run);
+        break;
+      case "candidate.validate":
+        await runCandidateValidate(root, request, run);
+        break;
+      case "dossier.generate":
+        await runDossier(root, request, run);
+        break;
+      default:
+        throw new Error(`Unhandled action kind: ${request.action_kind}`);
+    }
+    run.status = "succeeded";
+  } catch (error) {
+    const activeStep = run.steps.find((step) => step.status === "running");
+    if (activeStep) failStep(activeStep, error.message);
+    run.status = "failed";
+    run.error = {
+      code: error.code || "action_failed",
+      message: error.message,
+      retryable: error.retryable !== false,
+    };
+  } finally {
+    run.completed_at = now();
+    await persistRun(root, run);
+  }
+
+  return run;
+}
+
+export async function listVegaActionRuns(rootDir, { limit = 25 } = {}) {
+  const dir = safeReviewPath(path.resolve(rootDir), "action-runs");
+  let entries = [];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+  const runs = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    const value = await readJson(path.join(dir, entry.name), null);
+    if (value) runs.push(value);
+  }
+  return runs
+    .sort((left, right) => String(right.completed_at || "").localeCompare(String(left.completed_at || "")))
+    .slice(0, limit);
+}

--- a/src/server/action-bridge.js
+++ b/src/server/action-bridge.js
@@ -13,7 +13,6 @@ import {
   updateResearchQueue,
 } from "./house-model.js";
 import {
-  buildPromotionProposal,
   buildSkillCandidateIngestion,
   getSkillCandidate,
   validateSkillCandidate,
@@ -28,12 +27,37 @@ import {
 const ACTION_SCHEMA_VERSION = "vega.action-result.v1";
 const REVIEW_STATE = "pending";
 const VISIBILITY = "internal";
+const MUTATING_ACTIONS = new Set(["snapshot.resolve", "candidate.build", "dossier.generate", "review.queue"]);
+const ACTION_ALLOWED_KEYS = new Set(["action_kind", "repo", "candidate_id", "parameters", "write", "confirmation_ref"]);
+const REPO_ALLOWED_KEYS = new Set(["name", "author", "nwo"]);
+const PARAM_ALLOWED_KEYS = new Set([
+  "artifactKind",
+  "artifact_kind",
+  "candidate_id",
+  "confirmationRef",
+  "confirmation_ref",
+  "limit",
+  "notes",
+  "priority",
+  "ref",
+  "status",
+  "target",
+]);
+const activeMutationByRepo = new Map();
+const activeDuplicateRuns = new Map();
 const ACTION_KINDS = new Set([
   "repo.inspect",
   "snapshot.resolve",
   "candidate.build",
   "candidate.validate",
   "dossier.generate",
+  "review.queue",
+  "ops-kit.generate",
+  "mission.generate",
+]);
+const REPO_REQUIRED_ACTIONS = new Set([
+  "repo.inspect",
+  "snapshot.resolve",
   "review.queue",
   "ops-kit.generate",
   "mission.generate",
@@ -47,6 +71,66 @@ function sha256(value) {
   return crypto.createHash("sha256").update(value).digest("hex");
 }
 
+function stableStringify(value) {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function inputDigest(value) {
+  return `sha256:${sha256(stableStringify(value))}`;
+}
+
+function publicError(error) {
+  return {
+    code: error.code || "action_failed",
+    message: error.message || "Vega action failed.",
+    retryable: error.retryable !== false,
+  };
+}
+
+function actionError(message, code = "invalid_request", retryable = false) {
+  return Object.assign(new Error(message), { code, retryable });
+}
+
+function hasControlCharacters(value) {
+  return /[\u0000-\u001F\u007F]/.test(String(value || ""));
+}
+
+function validateIdentifier(value, label) {
+  const next = String(value || "").trim();
+  if (!next || hasControlCharacters(next) || next.includes("..") || next.includes("\\") || next.startsWith("/") || next.startsWith("~")) {
+    throw actionError(`Invalid ${label}.`, `invalid_${label}`, false);
+  }
+  if (!/^[A-Za-z0-9_.-]+$/.test(next)) {
+    throw actionError(`Invalid ${label}.`, `invalid_${label}`, false);
+  }
+  return next;
+}
+
+function validateNwo(value) {
+  const next = String(value || "").trim();
+  if (!next) return "";
+  if (hasControlCharacters(next) || next.includes("..") || next.includes("\\") || next.startsWith("/") || next.startsWith("~")) {
+    throw actionError("Invalid repository identity.", "invalid_repository_identity", false);
+  }
+  const parts = next.split("/");
+  if (parts.length !== 2) {
+    throw actionError("Repository identity must be owner/name.", "invalid_repository_identity", false);
+  }
+  return `${validateIdentifier(parts[0], "repository_owner")}/${validateIdentifier(parts[1], "repository_name")}`;
+}
+
+function rejectUnknownKeys(value, allowed, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return;
+  const unknown = Object.keys(value).filter((key) => !allowed.has(key));
+  if (unknown.length > 0) {
+    throw actionError(`Unknown ${label} field(s): ${unknown.join(", ")}`, "unknown_request_field", false);
+  }
+}
+
 function nwoFromRepo(repo) {
   if (!repo) return "";
   if (repo.nwo) return String(repo.nwo);
@@ -54,16 +138,24 @@ function nwoFromRepo(repo) {
 }
 
 function normalizeRepoInput(repo = {}) {
-  const nwo = nwoFromRepo(repo);
+  rejectUnknownKeys(repo, REPO_ALLOWED_KEYS, "repo");
+  const nwo = validateNwo(nwoFromRepo(repo));
   const [authorFromNwo, nameFromNwo] = nwo.split("/");
+  const author = repo.author ? validateIdentifier(repo.author, "repository_owner") : authorFromNwo;
+  const name = repo.name ? validateIdentifier(repo.name, "repository_name") : nameFromNwo;
+  const normalizedNwo = validateNwo([author, name].filter(Boolean).join("/"));
+  if (!normalizedNwo) {
+    throw actionError("Repository identity is required.", "missing_repository", false);
+  }
   return {
-    name: repo.name || nameFromNwo,
-    author: repo.author || authorFromNwo,
-    nwo,
+    name,
+    author,
+    nwo: normalizedNwo,
   };
 }
 
 function normalizeRequest(request = {}) {
+  rejectUnknownKeys(request, ACTION_ALLOWED_KEYS, "request");
   const actionKind = String(request.action_kind || "");
   if (!ACTION_KINDS.has(actionKind)) {
     throw Object.assign(new Error(`Unsupported Vega action kind: ${actionKind || "missing"}`), {
@@ -71,18 +163,58 @@ function normalizeRequest(request = {}) {
       retryable: false,
     });
   }
+  const parameters = request.parameters && typeof request.parameters === "object" && !Array.isArray(request.parameters)
+    ? request.parameters
+    : {};
+  rejectUnknownKeys(parameters, PARAM_ALLOWED_KEYS, "parameters");
+  const candidateId = request.candidate_id || parameters.candidate_id || null;
+  if (
+    candidateId
+    && (
+      hasControlCharacters(candidateId)
+      || String(candidateId).includes("..")
+      || String(candidateId).includes("\\")
+      || String(candidateId).startsWith("/")
+      || String(candidateId).startsWith("~")
+      || !/^[A-Za-z0-9_.:-]+$/.test(String(candidateId))
+    )
+  ) {
+    throw actionError("Invalid candidate id.", "invalid_candidate_id", false);
+  }
+  const repo = request.repo ? normalizeRepoInput(request.repo) : null;
+  if (REPO_REQUIRED_ACTIONS.has(actionKind) && !repo) {
+    throw actionError("Repository identity is required.", "missing_repository", false);
+  }
+  if (!repo && !candidateId && ["candidate.build", "candidate.validate", "dossier.generate"].includes(actionKind)) {
+    throw actionError("Repository identity or candidate id is required.", "missing_action_target", false);
+  }
   return {
     action_kind: actionKind,
-    repo: normalizeRepoInput(request.repo || {}),
-    candidate_id: request.candidate_id || request.parameters?.candidate_id || null,
-    parameters: request.parameters && typeof request.parameters === "object" ? request.parameters : {},
+    repo,
+    candidate_id: candidateId ? String(candidateId) : null,
+    parameters,
     write: request.write === true,
+    confirmation_ref: request.confirmation_ref || parameters.confirmation_ref || parameters.confirmationRef || null,
   };
 }
 
-function actionId(request) {
+function runId(request) {
   const target = request.candidate_id || request.repo?.nwo || `${request.repo?.author || ""}/${request.repo?.name || ""}`;
   return `vega-action-${slug(`${request.action_kind}-${target || "unknown"}`)}-${Date.now()}`;
+}
+
+function duplicateKey(request) {
+  return inputDigest({
+    action_kind: request.action_kind,
+    repo: request.repo,
+    candidate_id: request.candidate_id,
+    parameters: request.parameters,
+    write: request.write,
+  });
+}
+
+function repoLockKey(request) {
+  return request.repo?.nwo || request.candidate_id || "unknown";
 }
 
 function relativeToRoot(root, filePath) {
@@ -105,9 +237,15 @@ function safeReviewPath(root, ...segments) {
   return target;
 }
 
-async function writeJson(filePath, value) {
+async function atomicWrite(filePath, content) {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  await fs.writeFile(tmpPath, content, "utf8");
+  await fs.rename(tmpPath, filePath);
+}
+
+async function writeJson(filePath, value) {
+  await atomicWrite(filePath, `${JSON.stringify(value, null, 2)}\n`);
 }
 
 async function readJson(filePath, fallback = null) {
@@ -120,8 +258,7 @@ async function readJson(filePath, fallback = null) {
 }
 
 async function writeText(filePath, value) {
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.writeFile(filePath, value, "utf8");
+  await atomicWrite(filePath, value);
 }
 
 function createStep(id, label) {
@@ -181,13 +318,19 @@ function actionRepo(repo) {
 }
 
 async function persistRun(root, run) {
-  const filePath = safeReviewPath(root, "action-runs", `${slug(run.action_id)}.json`);
-  await writeJson(filePath, run);
-  run.artifacts.push({
+  const repoScope = run.repo?.nwo ? slug(run.repo.nwo) : "unknown-repo";
+  const filePath = safeReviewPath(root, "action-runs", repoScope, `${slug(run.run_id)}.json`);
+  const actionRunArtifact = {
     kind: "action-run",
     path: relativeToRoot(root, filePath),
-    checksum: `sha256:${sha256(JSON.stringify(run))}`,
-  });
+    checksum: `sha256:${sha256(JSON.stringify({ ...run, artifacts: [...run.artifacts] }))}`,
+  };
+  const runForDisk = {
+    ...run,
+    artifacts: [...run.artifacts, actionRunArtifact],
+  };
+  await writeJson(filePath, runForDisk);
+  run.artifacts = runForDisk.artifacts;
 }
 
 async function runRepoInspect(root, request, run) {
@@ -294,6 +437,9 @@ async function runSnapshot(root, request, run) {
   const step = createStep("snapshot.resolve", request.write ? "Resolve and cache immutable source snapshot" : "Check cached immutable source snapshot");
   run.steps.push(step);
   run.repo = actionRepo(repo);
+  if (request.write && !request.confirmation_ref) {
+    throw actionError("snapshot.resolve with network/cache writes requires confirmation_ref.", "confirmation_required", false);
+  }
   const result = request.write
     ? await resolveSourceSnapshot(repo, { projectRoot: root, ref: request.parameters.ref || null, write: true })
     : await checkSourceSnapshot(repo, { projectRoot: root });
@@ -335,7 +481,7 @@ async function findCandidateForRequest(root, request) {
   return result.candidates.find((candidate) => candidate.source_repository?.nwo?.toLowerCase() === nwo.toLowerCase()) || null;
 }
 
-async function writeCandidateAndProposal(root, candidate, run) {
+async function writeCandidateArtifact(root, candidate, run) {
   const safeId = slug(candidate.candidate_id);
   const candidatePath = safeReviewPath(root, "skill-candidates", `${safeId}.json`);
   await writeJson(candidatePath, candidate);
@@ -344,18 +490,6 @@ async function writeCandidateAndProposal(root, candidate, run) {
     path: relativeToRoot(root, candidatePath),
     checksum: candidate.content_checksum,
   });
-
-  const proposal = buildPromotionProposal(candidate, {
-    reviewArtifactRef: relativeToRoot(root, candidatePath),
-  });
-  const proposalPath = safeReviewPath(root, "capability-promotions", `${safeId}.json`);
-  await writeJson(proposalPath, proposal);
-  run.artifacts.push({
-    kind: "capability-promotion-proposal",
-    path: relativeToRoot(root, proposalPath),
-    checksum: `sha256:${sha256(JSON.stringify(proposal))}`,
-  });
-  return proposal;
 }
 
 async function runCandidateBuild(root, request, run) {
@@ -373,14 +507,15 @@ async function runCandidateBuild(root, request, run) {
   };
   run.candidate_id = candidate.candidate_id;
   const validation = validateSkillCandidate(candidate);
-  let proposal = buildPromotionProposal(candidate);
+  if (!validation.valid) {
+    throw actionError("Candidate build is blocked until an immutable source snapshot and safety validation pass.", "candidate_validation_blocked", false);
+  }
   if (request.write !== false) {
-    proposal = await writeCandidateAndProposal(root, candidate, run);
+    await writeCandidateArtifact(root, candidate, run);
   }
   run.result = {
     candidate,
     validation,
-    proposal,
     wrote: request.write !== false,
   };
   finishStep(step, `${candidate.candidate_id} (${validation.valid ? "valid" : "blocked"})`);
@@ -427,7 +562,9 @@ async function runDossier(root, request, run) {
   }
 
   const validation = validateSkillCandidate(candidate);
-  const proposal = buildPromotionProposal(candidate);
+  if (!validation.valid) {
+    throw actionError("Dossier generation is blocked until candidate validation passes.", "candidate_validation_blocked", false);
+  }
   const safeId = slug(candidate.candidate_id);
   const packetDir = safeReviewPath(root, "approval-packets", safeId);
   const snapshot = candidate.source_snapshot_identity?.artifact_ref
@@ -449,7 +586,13 @@ async function runDossier(root, request, run) {
     ].join("\n")],
     ["01-candidate.json", stablePrettyStringify(candidate)],
     ["02-validation.json", stablePrettyStringify(validation)],
-    ["03-promotion-proposal.json", stablePrettyStringify(proposal)],
+    ["03-promotion-boundary.md", [
+      `# Promotion Boundary: ${candidate.name}`,
+      "",
+      "Promotion proposals, Core-X dry-runs, bundle review, and apply are locked in this Vega UI flow.",
+      "This dossier does not approve, promote, install, or mutate Core-X registries.",
+      "",
+    ].join("\n")],
     ["04-source-snapshot.json", stablePrettyStringify(snapshot || { missing: candidate.source_snapshot_identity?.artifact_ref || null })],
     ["05-evidence.md", [
       `# Evidence: ${candidate.name}`,
@@ -541,21 +684,47 @@ async function runDossier(root, request, run) {
 export async function executeVegaAction(rootDir, rawRequest = {}) {
   const root = path.resolve(rootDir);
   const request = normalizeRequest(rawRequest);
+  const key = duplicateKey(request);
+  if (activeDuplicateRuns.has(key)) {
+    return activeDuplicateRuns.get(key);
+  }
+  const execution = executeVegaActionInternal(root, request, rawRequest)
+    .finally(() => {
+      activeDuplicateRuns.delete(key);
+    });
+  activeDuplicateRuns.set(key, execution);
+  return execution;
+}
+
+async function executeVegaActionInternal(root, request, rawRequest) {
   const started = now();
   const run = {
     schema_version: ACTION_SCHEMA_VERSION,
-    action_id: actionId(request),
+    run_id: runId(request),
+    action_id: request.action_kind,
     action_kind: request.action_kind,
     status: "running",
     review_state: REVIEW_STATE,
     visibility: VISIBILITY,
+    requested_at: started,
     started_at: started,
     completed_at: started,
+    confirmation_ref: request.confirmation_ref,
+    input_digest: inputDigest(rawRequest),
+    warnings: [],
     steps: [],
     artifacts: [],
   };
 
   try {
+    const lockKey = repoLockKey(request);
+    const mutating = MUTATING_ACTIONS.has(request.action_kind) && request.write !== false;
+    if (mutating && activeMutationByRepo.has(lockKey)) {
+      throw actionError(`Another mutating Vega action is already running for ${lockKey}.`, "repository_action_locked", true);
+    }
+    if (mutating) {
+      activeMutationByRepo.set(lockKey, run.run_id);
+    }
     switch (request.action_kind) {
       case "repo.inspect":
         await runRepoInspect(root, request, run);
@@ -588,13 +757,14 @@ export async function executeVegaAction(rootDir, rawRequest = {}) {
   } catch (error) {
     const activeStep = run.steps.find((step) => step.status === "running");
     if (activeStep) failStep(activeStep, error.message);
-    run.status = "failed";
-    run.error = {
-      code: error.code || "action_failed",
-      message: error.message,
-      retryable: error.retryable !== false,
-    };
+    run.status = error.retryable === false ? "blocked" : "failed";
+    run.error = publicError(error);
+    run.error_code = run.error.code;
   } finally {
+    const lockKey = repoLockKey(request);
+    if (activeMutationByRepo.get(lockKey) === run.run_id) {
+      activeMutationByRepo.delete(lockKey);
+    }
     run.completed_at = now();
     await persistRun(root, run);
   }
@@ -605,15 +775,30 @@ export async function executeVegaAction(rootDir, rawRequest = {}) {
 export async function listVegaActionRuns(rootDir, { limit = 25 } = {}) {
   const dir = safeReviewPath(path.resolve(rootDir), "action-runs");
   let entries = [];
+  async function collect(currentDir) {
+    let nested = [];
+    try {
+      nested = await fs.readdir(currentDir, { withFileTypes: true });
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+    for (const entry of nested) {
+      const entryPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        await collect(entryPath);
+      } else if (entry.isFile() && entry.name.endsWith(".json")) {
+        entries.push(entryPath);
+      }
+    }
+  }
   try {
-    entries = await fs.readdir(dir, { withFileTypes: true });
+    await collect(dir);
   } catch (error) {
     if (error?.code !== "ENOENT") throw error;
   }
   const runs = [];
-  for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
-    const value = await readJson(path.join(dir, entry.name), null);
+  for (const entryPath of entries) {
+    const value = await readJson(entryPath, null);
     if (value) runs.push(value);
   }
   return runs

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,3 +202,66 @@ export interface WeeklyResearchReview {
   researchCandidates: string[];
   actionItemIds: string[];
 }
+
+export type VegaActionKind =
+  | 'repo.inspect'
+  | 'snapshot.resolve'
+  | 'candidate.build'
+  | 'candidate.validate'
+  | 'dossier.generate'
+  | 'review.queue'
+  | 'ops-kit.generate'
+  | 'mission.generate';
+
+export type VegaActionStatus = 'queued' | 'running' | 'succeeded' | 'failed';
+
+export interface VegaActionRequest {
+  action_kind: VegaActionKind;
+  repo?: {
+    name: string;
+    author?: string;
+    nwo?: string;
+  };
+  candidate_id?: string;
+  parameters?: Record<string, unknown>;
+  write?: boolean;
+}
+
+export interface VegaActionStep {
+  id: string;
+  label: string;
+  status: VegaActionStatus;
+  detail?: string;
+  started_at?: string;
+  completed_at?: string;
+}
+
+export interface VegaActionResult {
+  schema_version: 'vega.action-result.v1';
+  action_id: string;
+  action_kind: VegaActionKind;
+  status: VegaActionStatus;
+  review_state: 'pending';
+  visibility: 'internal';
+  repo?: {
+    nwo: string;
+    name?: string;
+    author?: string;
+  };
+  candidate_id?: string;
+  started_at: string;
+  completed_at: string;
+  steps: VegaActionStep[];
+  artifacts: Array<{
+    kind: string;
+    path?: string;
+    title?: string;
+    checksum?: string;
+  }>;
+  result?: unknown;
+  error?: {
+    code: string;
+    message: string;
+    retryable: boolean;
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -213,7 +213,7 @@ export type VegaActionKind =
   | 'ops-kit.generate'
   | 'mission.generate';
 
-export type VegaActionStatus = 'queued' | 'running' | 'succeeded' | 'failed';
+export type VegaActionStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'blocked' | 'cancelled';
 
 export interface VegaActionRequest {
   action_kind: VegaActionKind;
@@ -238,7 +238,8 @@ export interface VegaActionStep {
 
 export interface VegaActionResult {
   schema_version: 'vega.action-result.v1';
-  action_id: string;
+  run_id: string;
+  action_id: VegaActionKind;
   action_kind: VegaActionKind;
   status: VegaActionStatus;
   review_state: 'pending';
@@ -249,8 +250,12 @@ export interface VegaActionResult {
     author?: string;
   };
   candidate_id?: string;
+  requested_at: string;
   started_at: string;
   completed_at: string;
+  confirmation_ref?: string | null;
+  input_digest: string;
+  warnings: string[];
   steps: VegaActionStep[];
   artifacts: Array<{
     kind: string;
@@ -264,4 +269,5 @@ export interface VegaActionResult {
     message: string;
     retryable: boolean;
   };
+  error_code?: string;
 }

--- a/tests/test-action-bridge.js
+++ b/tests/test-action-bridge.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { executeVegaAction, listVegaActionRuns } from "../src/server/action-bridge.js";
+
+async function writeJson(filePath, value) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+async function exists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function createFixtureRoot() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "vega-action-bridge-"));
+  const repo = {
+    name: "agent-toolkit",
+    author: "example",
+    description: "Deterministic agent workflow toolkit.",
+    stars: 1234,
+    forks: 98,
+    open_issues: 3,
+    date: "2026-01-01T00:00:00.000Z",
+    last_updated: "2026-06-01T00:00:00.000Z",
+    primary_language: "TypeScript",
+    language: "TypeScript",
+    license: "MIT",
+    languages: [{ language: "TypeScript", percentage: "100" }],
+    topics: ["agent", "workflow", "mcp"],
+    url: "https://github.com/example/agent-toolkit",
+    has_readme: true,
+  };
+
+  await writeJson(path.join(root, "data", "data.json"), [repo]);
+  await writeJson(path.join(root, "data", "my-repos.json"), []);
+  await writeJson(path.join(root, "data", "research-queue.json"), []);
+  await writeJson(path.join(root, "data", "action-items.json"), []);
+  await writeJson(path.join(root, "data", "repo-ops-kits.json"), []);
+  await writeJson(path.join(root, "data", "repo-signals.json"), [{
+    nwo: "example/agent-toolkit",
+    name: "agent-toolkit",
+    author: "example",
+    description: repo.description,
+    scope: "starred",
+    lastActivityAt: repo.last_updated,
+    staleness: "active",
+    researchStatus: "untracked",
+    adoptionScore: 82,
+    adoptionKind: "tool",
+    reasons: ["Agent workflow toolkit with MCP topics."],
+    houseSkills: ["repo-discovery", "skill-extraction", "repo-adoption"],
+    capabilities: ["agent-workflows", "mcp-tooling"],
+  }]);
+  await writeJson(path.join(root, "data", "skill-extractions.json"), [{
+    nwo: "example/agent-toolkit",
+    name: "agent-toolkit",
+    author: "example",
+    summary: "Reusable agent workflow patterns for MCP-backed tools.",
+    capabilities: ["agent-workflows", "mcp-tooling"],
+    houseSkills: ["skill-extraction", "repo-adoption"],
+    rules: ["Keep tool execution behind typed contracts."],
+    flows: ["skill-extraction-flow"],
+    adoptionKind: "tool",
+    codexBrief: "Codex mission",
+    claudeBrief: "Claude mission",
+  }]);
+
+  return root;
+}
+
+async function main() {
+  const root = await createFixtureRoot();
+  const repo = { name: "agent-toolkit", author: "example" };
+
+  const inspect = await executeVegaAction(root, {
+    action_kind: "repo.inspect",
+    repo,
+  });
+  assert.equal(inspect.status, "succeeded");
+  assert.equal(inspect.review_state, "pending");
+  assert.equal(inspect.visibility, "internal");
+  assert.equal(inspect.result.adoption_fit.kind, "tool");
+
+  const queued = await executeVegaAction(root, {
+    action_kind: "review.queue",
+    repo,
+    write: true,
+    parameters: { status: "queued", notes: "Fixture queue item." },
+  });
+  assert.equal(queued.status, "succeeded");
+  assert.equal(queued.result.item.status, "queued");
+  assert.ok(await exists(path.join(root, "data", "research-queue.json")));
+
+  const ops = await executeVegaAction(root, {
+    action_kind: "ops-kit.generate",
+    repo,
+    parameters: { target: "mlx", artifactKind: "readme" },
+  });
+  assert.equal(ops.status, "succeeded");
+  assert.equal(ops.result.artifacts.length, 1);
+  assert.equal(ops.result.artifacts[0].kind, "readme");
+
+  const mission = await executeVegaAction(root, {
+    action_kind: "mission.generate",
+    repo,
+    parameters: { target: "mlx" },
+  });
+  assert.equal(mission.status, "succeeded");
+  assert.match(mission.result.mission, /Local MLX Mission/);
+
+  const candidate = await executeVegaAction(root, {
+    action_kind: "candidate.build",
+    repo,
+    write: true,
+  });
+  assert.equal(candidate.status, "succeeded");
+  assert.equal(candidate.result.candidate.review_status, "pending");
+  assert.ok(candidate.artifacts.some((artifact) => artifact.kind === "skill-candidate"));
+  assert.ok(candidate.artifacts.every((artifact) => !String(artifact.path || "").startsWith("/")));
+
+  const validation = await executeVegaAction(root, {
+    action_kind: "candidate.validate",
+    candidate_id: candidate.result.candidate.candidate_id,
+  });
+  assert.equal(validation.status, "succeeded");
+  assert.equal(validation.result.candidate.candidate_id, candidate.result.candidate.candidate_id);
+
+  const dossier = await executeVegaAction(root, {
+    action_kind: "dossier.generate",
+    candidate_id: candidate.result.candidate.candidate_id,
+    write: true,
+  });
+  assert.equal(dossier.status, "succeeded");
+  assert.equal(dossier.result.file_count, 12);
+  assert.ok(dossier.artifacts.some((artifact) => artifact.path.endsWith("11-checksums.json")));
+
+  const runs = await listVegaActionRuns(root);
+  assert.ok(runs.length >= 6);
+  assert.ok(runs.every((run) => run.visibility === "internal"));
+  assert.ok(runs.every((run) => run.review_state === "pending"));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/test-action-bridge.js
+++ b/tests/test-action-bridge.js
@@ -6,6 +6,10 @@ import os from "node:os";
 import path from "node:path";
 
 import { executeVegaAction, listVegaActionRuns } from "../src/server/action-bridge.js";
+import {
+  buildSourceSnapshotFromEvidence,
+  stablePrettyStringify,
+} from "../scripts/source-snapshot-resolver.js";
 
 async function writeJson(filePath, value) {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
@@ -78,9 +82,96 @@ async function createFixtureRoot() {
   return root;
 }
 
+async function writeImmutableSnapshot(projectRoot, repo) {
+  const commitSha = "a".repeat(40);
+  const treeSha = "b".repeat(40);
+  const snapshot = buildSourceSnapshotFromEvidence({
+    repository: repo,
+    githubRepo: {
+      default_branch: "main",
+      description: repo.description,
+      language: repo.primary_language,
+      license: { spdx_id: repo.license },
+      topics: repo.topics,
+      private: false,
+    },
+    requestedRef: "main",
+    refType: "branch",
+    commit: {
+      sha: commitSha,
+      tree_sha: treeSha,
+      committed_at: "2026-06-12T00:00:00.000Z",
+    },
+    tree: {
+      sha: treeSha,
+      truncated: false,
+    },
+    evidence: [
+      {
+        kind: "readme",
+        path: "README.md",
+        blob_sha: "c".repeat(40),
+        content_sha256: "sha256:35a528211dbf54569e622969c569685ea27156d37373637c4751ded08e9d3f4e",
+        size: 52,
+        text_preview: "# Agent Toolkit\n\nDeterministic agent workflow toolkit.",
+      },
+      {
+        kind: "license",
+        path: "LICENSE",
+        blob_sha: "d".repeat(40),
+        content_sha256: "sha256:2c73f0eec270c48d35dbe2f0b742d3a45eb1fda715d9c98a5d271610000784f7",
+        size: 38,
+        text_preview: "MIT License\n\nPermission is hereby granted...",
+      },
+      {
+        kind: "manifest",
+        path: "package.json",
+        blob_sha: "e".repeat(40),
+        content_sha256: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        size: 28,
+        text_preview: "{\"name\":\"agent-toolkit\"}",
+      },
+    ],
+  });
+  const snapshotPath = path.join(projectRoot, snapshot.artifact_ref);
+  await fs.mkdir(path.dirname(snapshotPath), { recursive: true });
+  await fs.writeFile(snapshotPath, stablePrettyStringify(snapshot), "utf8");
+  await writeJson(path.join(projectRoot, "data", "review", "source-snapshots", "index.json"), {
+    entries: {
+      "example/agent-toolkit": {
+        nwo: "example/agent-toolkit",
+        artifact_ref: snapshot.artifact_ref,
+        snapshot_id: snapshot.id,
+        resolved_commit_sha: snapshot.metadata.immutable.resolved_commit_sha,
+        resolved_tree_sha: snapshot.metadata.immutable.resolved_tree_sha,
+        evidence_contract_version: snapshot.metadata.immutable.evidence_contract_version,
+        evidence_digest: snapshot.metadata.immutable.evidence_digest,
+      },
+    },
+  });
+  return snapshot;
+}
+
 async function main() {
   const root = await createFixtureRoot();
   const repo = { name: "agent-toolkit", author: "example" };
+
+  await assert.rejects(
+    () => executeVegaAction(root, {
+      action_kind: "repo.inspect",
+      repo,
+      extra: true,
+    }),
+    /Unknown request field/,
+  );
+
+  await assert.rejects(
+    () => executeVegaAction(root, {
+      action_kind: "repo.inspect",
+      repo: { name: "../agent-toolkit", author: "example" },
+    }),
+    /Invalid repository identity/,
+  );
 
   const inspect = await executeVegaAction(root, {
     action_kind: "repo.inspect",
@@ -118,15 +209,49 @@ async function main() {
   assert.equal(mission.status, "succeeded");
   assert.match(mission.result.mission, /Local MLX Mission/);
 
+  const snapshotWithoutConfirmation = await executeVegaAction(root, {
+    action_kind: "snapshot.resolve",
+    repo,
+    write: true,
+  });
+  assert.equal(snapshotWithoutConfirmation.status, "blocked");
+  assert.equal(snapshotWithoutConfirmation.error_code, "confirmation_required");
+  assert.ok(snapshotWithoutConfirmation.artifacts.some((artifact) => artifact.kind === "action-run"));
+
+  const blockedCandidate = await executeVegaAction(root, {
+    action_kind: "candidate.build",
+    repo,
+    write: true,
+  });
+  assert.equal(blockedCandidate.status, "blocked");
+  assert.equal(blockedCandidate.error_code, "candidate_validation_blocked");
+  assert.ok(!blockedCandidate.artifacts.some((artifact) => artifact.kind === "skill-candidate"));
+
+  await writeImmutableSnapshot(root, {
+    ...repo,
+    description: "Deterministic agent workflow toolkit.",
+    primary_language: "TypeScript",
+    license: "MIT",
+    topics: ["agent", "workflow", "mcp"],
+    url: "https://github.com/example/agent-toolkit",
+  });
+
   const candidate = await executeVegaAction(root, {
     action_kind: "candidate.build",
     repo,
     write: true,
   });
   assert.equal(candidate.status, "succeeded");
+  assert.equal(candidate.action_id, "candidate.build");
+  assert.match(candidate.run_id, /^vega-action-candidate-build-/);
+  assert.match(candidate.input_digest, /^sha256:[a-f0-9]{64}$/);
+  assert.equal(candidate.requested_at.length > 0, true);
+  assert.deepEqual(candidate.warnings, []);
   assert.equal(candidate.result.candidate.review_status, "pending");
   assert.ok(candidate.artifacts.some((artifact) => artifact.kind === "skill-candidate"));
+  assert.ok(candidate.artifacts.some((artifact) => artifact.kind === "action-run"));
   assert.ok(candidate.artifacts.every((artifact) => !String(artifact.path || "").startsWith("/")));
+  assert.equal(await exists(path.join(root, "data", "review", "capability-promotion-proposals")), false);
 
   const validation = await executeVegaAction(root, {
     action_kind: "candidate.validate",
@@ -143,11 +268,16 @@ async function main() {
   assert.equal(dossier.status, "succeeded");
   assert.equal(dossier.result.file_count, 12);
   assert.ok(dossier.artifacts.some((artifact) => artifact.path.endsWith("11-checksums.json")));
+  assert.ok(dossier.artifacts.some((artifact) => artifact.path.endsWith("03-promotion-boundary.md")));
+  assert.ok(!dossier.artifacts.some((artifact) => artifact.path.includes("promotion-proposal")));
 
   const runs = await listVegaActionRuns(root);
   assert.ok(runs.length >= 6);
   assert.ok(runs.every((run) => run.visibility === "internal"));
   assert.ok(runs.every((run) => run.review_state === "pending"));
+  assert.ok(runs.every((run) => run.run_id));
+  assert.ok(runs.every((run) => run.input_digest));
+  assert.ok(runs.every((run) => run.artifacts.some((artifact) => artifact.kind === "action-run")));
 }
 
 main().catch((error) => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,7 @@
 import { defineConfig } from 'vite';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { executeVegaAction, listVegaActionRuns } from './src/server/action-bridge.js';
 
 // Recreate __dirname in ESM
 const __filename = fileURLToPath(import.meta.url);
@@ -15,8 +16,75 @@ const eventBusTarget = process.env.VITE_EVENT_BUS_SSE_PROXY_TARGET
   || process.env.VITE_LOCAL_EVENT_BUS_URL
   || 'http://127.0.0.1:8085';
 
+async function readRequestJson(req) {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  const raw = Buffer.concat(chunks).toString('utf8').trim();
+  return raw ? JSON.parse(raw) : {};
+}
+
+function sendJson(res, statusCode, payload) {
+  res.statusCode = statusCode;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.end(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function vegaActionBridgePlugin() {
+  function installActionMiddlewares(middlewares) {
+    middlewares.use('/api/vega/actions/run', async (req, res) => {
+      if (req.method !== 'POST') {
+        sendJson(res, 405, { error: { code: 'method_not_allowed', message: 'Use POST.' } });
+        return;
+      }
+      try {
+        const body = await readRequestJson(req);
+        const result = await executeVegaAction(__dirname, body);
+        sendJson(res, result.status === 'failed' ? 400 : 200, result);
+      } catch (error) {
+        sendJson(res, 500, {
+          error: {
+            code: 'vega_action_bridge_failed',
+            message: error instanceof Error ? error.message : String(error),
+          },
+        });
+      }
+    });
+
+    middlewares.use('/api/vega/actions/runs', async (req, res) => {
+      if (req.method !== 'GET') {
+        sendJson(res, 405, { error: { code: 'method_not_allowed', message: 'Use GET.' } });
+        return;
+      }
+      try {
+        const runs = await listVegaActionRuns(__dirname, { limit: 50 });
+        sendJson(res, 200, { runs });
+      } catch (error) {
+        sendJson(res, 500, {
+          error: {
+            code: 'vega_action_runs_failed',
+            message: error instanceof Error ? error.message : String(error),
+          },
+        });
+      }
+    });
+  }
+
+  return {
+    name: 'vega-action-bridge',
+    configureServer(server) {
+      installActionMiddlewares(server.middlewares);
+    },
+    configurePreviewServer(server) {
+      installActionMiddlewares(server.middlewares);
+    },
+  };
+}
+
 export default defineConfig({
   root: rootDir,
+  plugins: [vegaActionBridgePlugin()],
   // Use './' for local dev, Vercel, Netlify, etc.
   // If deploying to GitHub Pages under /vega-lab/, change to base: '/vega-lab/'
   base: './',

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,14 +15,82 @@ const openResponsesTarget = process.env.VITE_EVENT_BUS_PROXY_TARGET
 const eventBusTarget = process.env.VITE_EVENT_BUS_SSE_PROXY_TARGET
   || process.env.VITE_LOCAL_EVENT_BUS_URL
   || 'http://127.0.0.1:8085';
+const actionBridgeHost = process.env.VEGA_ACTION_BRIDGE_HOST || 'localhost';
+const maxActionBodyBytes = Number.parseInt(process.env.VEGA_ACTION_MAX_BODY_BYTES || '65536', 10);
+const allowedActionOrigins = new Set(
+  String(process.env.VEGA_ACTION_ALLOWED_ORIGINS || '')
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean),
+);
+
+function bridgeError(code, message, statusCode = 400) {
+  return Object.assign(new Error(message), {
+    code,
+    statusCode,
+  });
+}
+
+function isLocalHostname(hostname) {
+  return ['localhost', '127.0.0.1', '::1', '[::1]'].includes(String(hostname || '').toLowerCase());
+}
+
+function hostnameFromHostHeader(hostHeader = '') {
+  const host = String(hostHeader || '').trim();
+  if (!host) return '';
+  if (host.startsWith('[')) return host.slice(1, host.indexOf(']'));
+  return host.split(':')[0];
+}
+
+function assertActionRequestAllowed(req, { requireJson = false } = {}) {
+  const host = hostnameFromHostHeader(req.headers.host);
+  if (!isLocalHostname(host)) {
+    throw bridgeError('forbidden_host', 'Vega actions are available only from a local development host.', 403);
+  }
+
+  const origin = req.headers.origin;
+  if (origin) {
+    const allowedByEnv = allowedActionOrigins.has(origin);
+    let originHost = '';
+    try {
+      originHost = new URL(origin).hostname;
+    } catch {
+      throw bridgeError('forbidden_origin', 'Invalid Origin header.', 403);
+    }
+    if (!allowedByEnv && !isLocalHostname(originHost)) {
+      throw bridgeError('forbidden_origin', 'Cross-origin Vega action requests are blocked.', 403);
+    }
+  }
+
+  if (requireJson) {
+    const contentType = String(req.headers['content-type'] || '').toLowerCase();
+    if (!contentType.includes('application/json')) {
+      throw bridgeError('unsupported_media_type', 'Use application/json for Vega action requests.', 415);
+    }
+    if (String(req.headers['x-vega-action-origin'] || '') !== 'vega-lab-ui') {
+      throw bridgeError('missing_action_origin', 'Missing Vega UI action origin header.', 403);
+    }
+  }
+}
 
 async function readRequestJson(req) {
   const chunks = [];
+  let received = 0;
   for await (const chunk of req) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    received += buffer.length;
+    if (received > maxActionBodyBytes) {
+      throw bridgeError('payload_too_large', 'Vega action request body is too large.', 413);
+    }
+    chunks.push(buffer);
   }
   const raw = Buffer.concat(chunks).toString('utf8').trim();
-  return raw ? JSON.parse(raw) : {};
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw bridgeError('invalid_json', 'Request body must be valid JSON.', 400);
+  }
 }
 
 function sendJson(res, statusCode, payload) {
@@ -32,23 +100,34 @@ function sendJson(res, statusCode, payload) {
 }
 
 function vegaActionBridgePlugin() {
+  // This bridge is Vite dev/preview middleware only. Static deployments have no local action executor.
+  function sendBridgeError(res, error, fallbackCode) {
+    const statusCode = error?.statusCode || fallbackCode;
+    sendJson(res, statusCode, {
+      error: {
+        code: error?.code || 'vega_action_bridge_failed',
+        message: error instanceof Error ? error.message : String(error),
+      },
+    });
+  }
+
   function installActionMiddlewares(middlewares) {
     middlewares.use('/api/vega/actions/run', async (req, res) => {
+      if (req.method === 'OPTIONS') {
+        sendJson(res, 403, { error: { code: 'forbidden_preflight', message: 'Cross-origin Vega action preflight is blocked.' } });
+        return;
+      }
       if (req.method !== 'POST') {
         sendJson(res, 405, { error: { code: 'method_not_allowed', message: 'Use POST.' } });
         return;
       }
       try {
+        assertActionRequestAllowed(req, { requireJson: true });
         const body = await readRequestJson(req);
         const result = await executeVegaAction(__dirname, body);
-        sendJson(res, result.status === 'failed' ? 400 : 200, result);
+        sendJson(res, 200, result);
       } catch (error) {
-        sendJson(res, 500, {
-          error: {
-            code: 'vega_action_bridge_failed',
-            message: error instanceof Error ? error.message : String(error),
-          },
-        });
+        sendBridgeError(res, error, 500);
       }
     });
 
@@ -58,15 +137,11 @@ function vegaActionBridgePlugin() {
         return;
       }
       try {
+        assertActionRequestAllowed(req);
         const runs = await listVegaActionRuns(__dirname, { limit: 50 });
         sendJson(res, 200, { runs });
       } catch (error) {
-        sendJson(res, 500, {
-          error: {
-            code: 'vega_action_runs_failed',
-            message: error instanceof Error ? error.message : String(error),
-          },
-        });
+        sendBridgeError(res, error, 500);
       }
     });
   }
@@ -101,6 +176,7 @@ export default defineConfig({
     },
   },
   server: {
+    host: actionBridgeHost,
     hmr: { overlay: true },
     open: true,
     proxy: {
@@ -115,6 +191,9 @@ export default defineConfig({
         rewrite: (path) => path.replace(/^\/bus/, ''),
       },
     },
+  },
+  preview: {
+    host: actionBridgeHost,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Adds a local Vega action bridge for typed repo workflows under /api/vega/actions/*.
- Routes core UI actions through deterministic local tools instead of prompt-only chat when possible.
- Writes internal pending action run, skill candidate, promotion proposal, and approval packet artifacts under ignored data/review/**.
- Adds fixture-backed action bridge tests.

## Verification
- npm test
- npm run build
- node --check src/server/action-bridge.js
- node --check tests/test-action-bridge.js
- node --check vite.config.js
- git diff --check

## Safety
- No generated data/public JSON committed.
- No registry mutation or skill promotion.
- No Core-X apply path.
- Existing local diverged main was untouched.