### PR TITLE
fix(vega): correct durable action post-merge regression

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -23,6 +23,18 @@ const allowedActionOrigins = new Set(
     .map((origin) => origin.trim())
     .filter(Boolean),
 );
+const clientBridgeErrorCodes = new Set([
+  'unsupported_action_kind',
+  'unknown_request_field',
+  'invalid_request',
+  'invalid_json',
+  'invalid_repository_identity',
+  'invalid_repository_owner',
+  'invalid_repository_name',
+  'invalid_candidate_id',
+  'missing_repository',
+  'missing_action_target',
+]);
 
 function bridgeError(code, message, statusCode = 400) {
   return Object.assign(new Error(message), {
@@ -102,7 +114,7 @@ function sendJson(res, statusCode, payload) {
 function vegaActionBridgePlugin() {
   // This bridge is Vite dev/preview middleware only. Static deployments have no local action executor.
   function sendBridgeError(res, error, fallbackCode) {
-    const statusCode = error?.statusCode || fallbackCode;
+    const statusCode = error?.statusCode || (clientBridgeErrorCodes.has(error?.code) ? 400 : fallbackCode);
     sendJson(res, statusCode, {
       error: {
         code: error?.code || 'vega_action_bridge_failed',
@@ -177,6 +189,7 @@ export default defineConfig({
   },
   server: {
     host: actionBridgeHost,
+    cors: false,
     hmr: { overlay: true },
     open: true,
     proxy: {
@@ -194,6 +207,7 @@ export default defineConfig({
   },
   preview: {
     host: actionBridgeHost,
+    cors: false,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Disable Vite default CORS handling for dev/preview so /api/vega/actions/run rejects OPTIONS/preflight through the Vega bridge.
- Map local validation and unknown-action bridge errors to client 400 responses instead of generic 500s.

## Validation
- npm test
- npm run build
- node --check src/server/action-bridge.js
- node --check vite.config.js
- node --check tests/test-action-bridge.js
- npm run test:source-snapshots
- npm run test:skill-candidate-ingestion
- npm run test:mcp
- npm run test:corex-contract-snapshots
- dev and preview HTTP matrix: local accepted, foreign origin rejected, OPTIONS rejected, non-JSON rejected, oversized rejected, unknown action rejected without stack/secrets

## Scope
Narrow post-merge corrective PR for #49 runtime boundary validation only. No new actions, no Gemma/chat changes, no Skill Seekers approval, no Core-X apply.