### PR TITLE
feat(vega): compile curated skill candidate profiles

### DIFF
--- a/config/skill-candidate-profiles/schema.json
+++ b/config/skill-candidate-profiles/schema.json
@@ -1,0 +1,274 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:vega:schema:vega.skill-candidate-profile.v1",
+  "title": "Vega Skill Candidate Profile v1",
+  "description": "Tracked Vega profile that compiles curated repository evidence into a deterministic Core-X skill candidate.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "profile_id",
+    "source",
+    "candidate",
+    "policy"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "vega.skill-candidate-profile.v1"
+    },
+    "profile_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+    },
+    "source": {
+      "type": "object",
+      "required": ["repository", "commit"],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+        },
+        "commit": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{40}$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "candidate": {
+      "type": "object",
+      "required": [
+        "suggested_skill_id",
+        "name",
+        "description",
+        "lane",
+        "scope",
+        "runtime"
+      ],
+      "properties": {
+        "suggested_skill_id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "lane": {
+          "type": "string",
+          "enum": [
+            "visual-runtime",
+            "agent-workflows",
+            "research-intelligence",
+            "frontend-ui",
+            "developer-tooling",
+            "core-capability"
+          ]
+        },
+        "scope": {
+          "type": "string",
+          "enum": ["house-local", "shared"]
+        },
+        "runtime": {
+          "type": "string",
+          "enum": ["markdown-prompt", "contract-only", "review-dossier"]
+        },
+        "required_tools_services": {
+          "$ref": "#/$defs/tools_services"
+        },
+        "compatibility_assumptions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "evidence_summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "duplicate_matches": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/duplicate_match"
+          }
+        },
+        "conflict_findings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/finding"
+          }
+        },
+        "risk_findings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/finding"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "policy": {
+      "$ref": "#/$defs/policy"
+    }
+  },
+  "$defs": {
+    "string_list": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "tools_services": {
+      "type": "object",
+      "required": ["tools", "services"],
+      "properties": {
+        "tools": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "services": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "policy": {
+      "type": "object",
+      "required": [
+        "purpose",
+        "when_to_use",
+        "when_not_to_use",
+        "relationship_to_vega",
+        "safe_evaluation_workflow",
+        "immutable_provenance_requirements",
+        "license_requirements",
+        "local_first_policy",
+        "network_restrictions",
+        "credential_restrictions",
+        "human_approval_gates",
+        "allowed_outputs",
+        "failure_conditions",
+        "prohibited_actions",
+        "source_attribution"
+      ],
+      "properties": {
+        "purpose": {
+          "type": "string",
+          "minLength": 1
+        },
+        "when_to_use": {
+          "$ref": "#/$defs/string_list"
+        },
+        "when_not_to_use": {
+          "$ref": "#/$defs/string_list"
+        },
+        "relationship_to_vega": {
+          "type": "string",
+          "minLength": 1
+        },
+        "safe_evaluation_workflow": {
+          "$ref": "#/$defs/string_list"
+        },
+        "immutable_provenance_requirements": {
+          "$ref": "#/$defs/string_list"
+        },
+        "license_requirements": {
+          "$ref": "#/$defs/string_list"
+        },
+        "local_first_policy": {
+          "type": "string",
+          "minLength": 1
+        },
+        "network_restrictions": {
+          "$ref": "#/$defs/string_list"
+        },
+        "credential_restrictions": {
+          "$ref": "#/$defs/string_list"
+        },
+        "human_approval_gates": {
+          "$ref": "#/$defs/string_list"
+        },
+        "allowed_outputs": {
+          "$ref": "#/$defs/string_list"
+        },
+        "failure_conditions": {
+          "$ref": "#/$defs/string_list"
+        },
+        "prohibited_actions": {
+          "$ref": "#/$defs/string_list"
+        },
+        "source_attribution": {
+          "$ref": "#/$defs/string_list"
+        }
+      },
+      "additionalProperties": false
+    },
+    "duplicate_match": {
+      "type": "object",
+      "required": ["kind", "target", "confidence", "source"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target": {
+          "type": "string",
+          "minLength": 1
+        },
+        "label": {
+          "type": "string"
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "finding": {
+      "type": "object",
+      "required": ["kind", "severity", "summary"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["info", "warning", "blocking"]
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/config/skill-candidate-profiles/skill-seekers-ingestion-review.json
+++ b/config/skill-candidate-profiles/skill-seekers-ingestion-review.json
@@ -1,0 +1,159 @@
+{
+  "schema_version": "vega.skill-candidate-profile.v1",
+  "profile_id": "skill-seekers-ingestion-review",
+  "source": {
+    "repository": "yusufkaraaslan/Skill_Seekers",
+    "commit": "61911d0efa72ae506acf7242f4775a9ddc6a3466"
+  },
+  "candidate": {
+    "suggested_skill_id": "skill-seekers-ingestion-review",
+    "name": "Skill Seekers Ingestion Review",
+    "description": "Reference and governance skill for reviewing external skill-ingestion systems without executing upstream Skill Seekers runtime flows.",
+    "lane": "agent-workflows",
+    "scope": "shared",
+    "runtime": "markdown-prompt",
+    "required_tools_services": {
+      "tools": [
+        "vega-lab:source-snapshot",
+        "vega-lab:repo-signals",
+        "vega-lab:skill-candidates",
+        "vega-lab:human-review-dossier",
+        "core-x:skill-registry-check"
+      ],
+      "services": []
+    },
+    "compatibility_assumptions": [
+      "Reference and governance markdown only; no upstream Skill Seekers code execution is part of this candidate.",
+      "No install, upload, publish, marketplace, vector database, cloud storage, browser scraping, service startup, or registry mutation behavior is included.",
+      "Runtime adapter work is deferred until a separate operator-approved design reviews dependencies, credentials, subprocesses, MCP transport, and filesystem writes.",
+      "Candidate relies on pinned Vega source snapshot evidence and does not copy third-party source code or long README bodies."
+    ],
+    "evidence_summary": "Pinned evidence shows a Python skill-generation toolkit with CLI, MCP, scraping, packaging, upload, cloud, vector database, and provider-adapter surfaces. The safe Core-X use is a governance and reference checklist for reviewing such systems, not an executable adapter.",
+    "duplicate_matches": [
+      {
+        "kind": "similar-capability",
+        "target": "skill-creator",
+        "label": "Core-X already has local skill creation workflows; this candidate should stay a governance review companion.",
+        "confidence": 0.62,
+        "source": "curated-profile"
+      }
+    ],
+    "conflict_findings": [
+      {
+        "kind": "runtime-scope",
+        "severity": "warning",
+        "summary": "Upstream runtime can install, upload, publish, scrape, run MCP servers, and use credentials; executable integration is out of scope for this candidate.",
+        "source_refs": [
+          "pyproject.toml",
+          "README.md",
+          "src/skill_seekers/mcp/server_fastmcp.py"
+        ]
+      }
+    ],
+    "risk_findings": [
+      {
+        "kind": "network-and-credential-surface",
+        "severity": "warning",
+        "summary": "Runtime adapter work would require separate controls for network calls, provider credentials, cloud or vector database uploads, and repository publishing.",
+        "source_refs": [
+          "pyproject.toml",
+          "README.md"
+        ]
+      },
+      {
+        "kind": "subprocess-and-filesystem-surface",
+        "severity": "warning",
+        "summary": "Runtime adapter work would need explicit review for subprocess execution and filesystem writes before use in Core-X.",
+        "source_refs": [
+          "src/skill_seekers/mcp/tools/subprocess_utils.py"
+        ]
+      }
+    ]
+  },
+  "policy": {
+    "purpose": "Use this skill as a Core-X review guide for evaluating external skill-generation and repository-ingestion systems. It captures patterns observed in the pinned Skill Seekers source snapshot, but it does not install or run Skill Seekers.",
+    "when_to_use": [
+      "Review pinned Skill Seekers evidence for ingestion, package-generation, MCP exposure, and review-gate patterns.",
+      "Compare an external skill-ingestion repository against Core-X skill candidate contracts.",
+      "Draft concise Vega or human-review notes that preserve provenance and boundaries.",
+      "Evaluate whether a future runtime adapter deserves a separate approved design."
+    ],
+    "when_not_to_use": [
+      "Do not run upstream Skill Seekers commands or start its CLI, HTTP, or MCP server.",
+      "Do not scrape arbitrary sources, upload generated packages, publish to marketplaces, or mutate agent configuration.",
+      "Do not call credentialed provider APIs, cloud storage, vector databases, browser automation, or external enhancement services.",
+      "Do not install Core-X skills, approve candidates, create approved promotion proposals, or mutate registries."
+    ],
+    "relationship_to_vega": "Vega remains the evaluator, evidence compiler, candidate generator, conflict detector, and review layer. Skill Seekers is source evidence and reference material only.",
+    "safe_evaluation_workflow": [
+      "Confirm the immutable source snapshot id, repository, commit, tree, and evidence digest before using the profile.",
+      "Inspect pinned manifest, README, and license evidence only.",
+      "Classify runtime surfaces as reference-only, optional adapter work, prohibited by default, or operator-approved.",
+      "Produce a pending review note, candidate critique, or governance checklist.",
+      "Stop before install, apply, publish, upload, push, service start, credential use, or registry mutation."
+    ],
+    "immutable_provenance_requirements": [
+      "Repository must be yusufkaraaslan/Skill_Seekers.",
+      "Commit must be 61911d0efa72ae506acf7242f4775a9ddc6a3466.",
+      "Tree must be 35e280375a98e0c68347d1edecad8f330a6a9741.",
+      "Snapshot must be vega:source-snapshot:yusufkaraaslan-skill-seekers:61911d0efa72:35e280375a98:62309b15137e.",
+      "Evidence digest must be sha256:62309b15137eb9827e403baa10a75fcf27412e60173d5313d02341b218b0b44d."
+    ],
+    "license_requirements": [
+      "License evidence must come from the pinned source snapshot.",
+      "MIT or other compatible license evidence still requires human confirmation before promotion.",
+      "Missing, changed, incompatible, or restricted license evidence blocks promotion and runtime adapter work."
+    ],
+    "local_first_policy": "Default to offline review of pinned evidence. This profile does not grant runtime network access, model downloads, Warehouse mutation, memory deletion, or external publishing.",
+    "network_restrictions": [
+      "Do not fetch or scrape through the upstream Skill Seekers runtime.",
+      "Do not use GitHub, browser, website, cloud, vector database, marketplace, or provider network calls from this skill.",
+      "Any future networked adapter requires a separate operator-approved design and ToolPolicy review."
+    ],
+    "credential_restrictions": [
+      "Do not request, echo, store, or infer credentials, tokens, API keys, OAuth grants, or secretsbank values.",
+      "Do not pass credentials to upstream Skill Seekers code or generated packages.",
+      "Stop if evidence or prompts include secrets or credential material."
+    ],
+    "human_approval_gates": [
+      "Human review is required before approving the candidate.",
+      "Human review is required before creating any promotion proposal that is not pending review.",
+      "Human review is required before any Core-X registry, skill directory, or ToolPolicy mutation.",
+      "Human review is required before designing or executing any runtime adapter."
+    ],
+    "allowed_outputs": [
+      "Reference checklist",
+      "Capability observations",
+      "Risk findings",
+      "Evidence and provenance report",
+      "Pending SKILL.md draft preview",
+      "Pending candidate critique"
+    ],
+    "failure_conditions": [
+      "Source repository, commit, tree, snapshot id, or evidence digest does not match the pinned profile.",
+      "License evidence is missing, changed, incompatible, restricted, or review-required without explicit human acceptance.",
+      "Prompt asks to execute upstream code, install dependencies, publish, upload, scrape, call providers, use credentials, or mutate Core-X.",
+      "Generated candidate includes copied third-party source code, long README bodies, secrets, or absolute local paths."
+    ],
+    "prohibited_actions": [
+      "Install Skill Seekers dependencies.",
+      "Run Skill Seekers CLI commands.",
+      "Start Skill Seekers HTTP or MCP servers.",
+      "Execute Skill Seekers subprocess helpers.",
+      "Scrape or fetch through upstream Skill Seekers runtime.",
+      "Upload generated packages.",
+      "Publish to a marketplace or repository.",
+      "Call cloud, vector database, browser automation, or provider enhancement services.",
+      "Use credentials, tokens, OAuth grants, API keys, or secretsbank values.",
+      "Mutate Core-X registries, skills, ToolPolicy, Warehouse, memory, or approvals.",
+      "Approve or promote this candidate automatically."
+    ],
+    "source_attribution": [
+      "Repository: yusufkaraaslan/Skill_Seekers",
+      "Commit: 61911d0efa72ae506acf7242f4775a9ddc6a3466",
+      "Tree: 35e280375a98e0c68347d1edecad8f330a6a9741",
+      "Snapshot: vega:source-snapshot:yusufkaraaslan-skill-seekers:61911d0efa72:35e280375a98:62309b15137e",
+      "Evidence digest: sha256:62309b15137eb9827e403baa10a75fcf27412e60173d5313d02341b218b0b44d"
+    ]
+  }
+}

--- a/contracts/corex/corex.vega-skill-candidate.v1.schema.json
+++ b/contracts/corex/corex.vega-skill-candidate.v1.schema.json
@@ -183,6 +183,58 @@
         "$ref": "#/$defs/finding"
       }
     },
+    "candidate_profile": {
+      "type": "object",
+      "required": [
+        "schema_version",
+        "profile_id",
+        "profile_ref",
+        "profile_digest",
+        "source",
+        "runtime"
+      ],
+      "properties": {
+        "schema_version": {
+          "type": "string",
+          "const": "vega.skill-candidate-profile.v1"
+        },
+        "profile_id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+        },
+        "profile_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "profile_digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "source": {
+          "type": "object",
+          "required": ["repository", "commit"],
+          "properties": {
+            "repository": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+            },
+            "commit": {
+              "type": "string",
+              "pattern": "^[a-f0-9]{40}$"
+            }
+          },
+          "additionalProperties": false
+        },
+        "runtime": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "policy": {
+      "$ref": "#/$defs/policy"
+    },
     "review_status": {
       "type": "string",
       "enum": ["pending", "approved", "rejected"]
@@ -217,6 +269,85 @@
     }
   },
   "$defs": {
+    "string_list": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "policy": {
+      "type": "object",
+      "required": [
+        "purpose",
+        "when_to_use",
+        "when_not_to_use",
+        "relationship_to_vega",
+        "safe_evaluation_workflow",
+        "immutable_provenance_requirements",
+        "license_requirements",
+        "local_first_policy",
+        "network_restrictions",
+        "credential_restrictions",
+        "human_approval_gates",
+        "allowed_outputs",
+        "failure_conditions",
+        "prohibited_actions",
+        "source_attribution"
+      ],
+      "properties": {
+        "purpose": {
+          "type": "string",
+          "minLength": 1
+        },
+        "when_to_use": {
+          "$ref": "#/$defs/string_list"
+        },
+        "when_not_to_use": {
+          "$ref": "#/$defs/string_list"
+        },
+        "relationship_to_vega": {
+          "type": "string",
+          "minLength": 1
+        },
+        "safe_evaluation_workflow": {
+          "$ref": "#/$defs/string_list"
+        },
+        "immutable_provenance_requirements": {
+          "$ref": "#/$defs/string_list"
+        },
+        "license_requirements": {
+          "$ref": "#/$defs/string_list"
+        },
+        "local_first_policy": {
+          "type": "string",
+          "minLength": 1
+        },
+        "network_restrictions": {
+          "$ref": "#/$defs/string_list"
+        },
+        "credential_restrictions": {
+          "$ref": "#/$defs/string_list"
+        },
+        "human_approval_gates": {
+          "$ref": "#/$defs/string_list"
+        },
+        "allowed_outputs": {
+          "$ref": "#/$defs/string_list"
+        },
+        "failure_conditions": {
+          "$ref": "#/$defs/string_list"
+        },
+        "prohibited_actions": {
+          "$ref": "#/$defs/string_list"
+        },
+        "source_attribution": {
+          "$ref": "#/$defs/string_list"
+        }
+      },
+      "additionalProperties": false
+    },
     "duplicate_match": {
       "type": "object",
       "required": ["kind", "target", "confidence", "source"],

--- a/contracts/corex/manifest.json
+++ b/contracts/corex/manifest.json
@@ -5,7 +5,7 @@
     {
       "name": "corex.vega-skill-candidate.v1.schema.json",
       "schema_version": "corex.vega-skill-candidate.v1",
-      "sha256": "sha256:50678acd7ee571fbeb6ff1882fc42b3e47e00ba5a66d9477fb46746a0609feac"
+      "sha256": "sha256:f80507d96b119a5bc4e107c159d8a4cba28625ffb3e0646e34eebfd138817f6d"
     },
     {
       "name": "corex.vega-skill-review.v1.schema.json",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:corex-contract-export": "node tests/test-corex-contract-export.js",
     "test:corex-contract-snapshots": "node tests/test-corex-contract-snapshots.js",
     "test:source-snapshots": "node tests/test-source-snapshot-resolver.js",
-    "test:skill-candidate-ingestion": "node tests/test-skill-candidate-ingestion.js",
+    "test:skill-candidate-ingestion": "node tests/test-skill-candidate-ingestion.js && node tests/test-skill-candidate-profiles.js",
     "test:action-bridge": "node tests/test-action-bridge.js",
     "test": "npm run lint && npm run test:data && npm run test:mcp && npm run test:action-bridge"
   },

--- a/scripts/build-skill-candidates.js
+++ b/scripts/build-skill-candidates.js
@@ -15,8 +15,10 @@ const projectRoot = path.resolve(__dirname, "..");
 
 const GENERATED_BY = "vega-lab:build-skill-candidates";
 const CANDIDATE_SCHEMA_VERSION = "corex.vega-skill-candidate.v1";
+const PROFILE_SCHEMA_VERSION = "vega.skill-candidate-profile.v1";
 const REVIEW_SCHEMA_VERSION = "corex.vega-skill-review.v1";
 const CONTRACTS_ROOT = path.join(projectRoot, "contracts", "corex");
+const PROFILE_CONFIG_DIRNAME = path.join("config", "skill-candidate-profiles");
 const TOOL = {
   tool_id: "vega.build_skill_candidates",
   name: "Vega Skill Candidate Ingestion",
@@ -40,6 +42,8 @@ const CANDIDATE_CHECKSUM_FIELDS = [
   "duplicate_matches",
   "conflict_findings",
   "risk_findings",
+  "candidate_profile",
+  "policy",
 ];
 
 const SECRET_PATTERNS = [
@@ -264,6 +268,120 @@ async function readJsonFiles(dirPath) {
     if (error?.code !== "ENOENT") throw error;
   }
   return results;
+}
+
+function relativePath(root, filePath) {
+  return path.relative(root, filePath).replaceAll(path.sep, "/");
+}
+
+function profileConfigDir(root) {
+  return path.join(root, PROFILE_CONFIG_DIRNAME);
+}
+
+function profileSchemaPath(root) {
+  return path.join(profileConfigDir(root), "schema.json");
+}
+
+function sourceSnapshotCommit(snapshot) {
+  const immutableCommit = snapshot?.metadata?.immutable?.resolved_commit_sha;
+  if (/^[a-f0-9]{40}$/i.test(String(immutableCommit || ""))) return String(immutableCommit).toLowerCase();
+  const sourceRef = String(snapshot?.source_ref || "");
+  const match = /@([a-f0-9]{40})$/i.exec(sourceRef);
+  return match ? match[1].toLowerCase() : "";
+}
+
+function profileSourceKey(repository, commit) {
+  return `${String(repository || "").toLowerCase()}@${String(commit || "").toLowerCase()}`;
+}
+
+function profileError(message, code = "invalid_skill_candidate_profile") {
+  return Object.assign(new Error(message), { code });
+}
+
+async function loadSkillCandidateProfiles(root) {
+  const dir = profileConfigDir(root);
+  if (!await pathExists(dir)) {
+    return { entries: [], bySource: new Map(), count: 0 };
+  }
+
+  const schemaPath = profileSchemaPath(root);
+  const schema = await readJson(schemaPath, null);
+  if (!schema) {
+    throw profileError(`Skill candidate profile schema is missing: ${relativePath(root, schemaPath)}`, "missing_skill_candidate_profile_schema");
+  }
+
+  const profileAjv = new Ajv2020({
+    allErrors: true,
+    coerceTypes: false,
+    strict: true,
+    useDefaults: false,
+  });
+  const validateProfile = profileAjv.compile(schema);
+  const profileIdToRef = new Map();
+  const targetSkillIdToRef = new Map();
+  const sourceToRef = new Map();
+  const entries = [];
+
+  for (const record of await readJsonFiles(dir)) {
+    if (path.resolve(record.filePath) === path.resolve(schemaPath)) continue;
+    const profile = record.value;
+    const valid = validateProfile(profile);
+    const ref = relativePath(root, record.filePath);
+    if (!valid) {
+      const errors = schemaErrors(validateProfile).join("; ");
+      throw profileError(`Invalid skill candidate profile ${ref}: ${errors}`);
+    }
+
+    const scanText = textForScanning(profile);
+    const blockers = [
+      ...patternFindings(LOCAL_PATH_PATTERNS, scanText, "absolute_local_path"),
+      ...patternFindings(SECRET_PATTERNS, scanText, "secret_or_credential"),
+    ];
+    if (blockers.length > 0) {
+      throw profileError(`Unsafe skill candidate profile ${ref}: ${blockers.map((blocker) => blocker.kind).join(", ")}`);
+    }
+
+    if (profileIdToRef.has(profile.profile_id)) {
+      throw profileError(`Duplicate skill candidate profile id ${profile.profile_id}: ${profileIdToRef.get(profile.profile_id)} and ${ref}`);
+    }
+    profileIdToRef.set(profile.profile_id, ref);
+
+    const targetSkillId = profile.candidate.suggested_skill_id;
+    if (targetSkillIdToRef.has(targetSkillId)) {
+      throw profileError(`Duplicate skill candidate target ${targetSkillId}: ${targetSkillIdToRef.get(targetSkillId)} and ${ref}`);
+    }
+    targetSkillIdToRef.set(targetSkillId, ref);
+
+    const sourceKey = profileSourceKey(profile.source.repository, profile.source.commit);
+    if (sourceToRef.has(sourceKey)) {
+      throw profileError(`Duplicate skill candidate source binding ${sourceKey}: ${sourceToRef.get(sourceKey)} and ${ref}`);
+    }
+    sourceToRef.set(sourceKey, ref);
+
+    const entry = {
+      profile,
+      profile_ref: ref,
+      profile_digest: `sha256:${sha256(stableStringify(profile))}`,
+    };
+    entries.push(entry);
+  }
+
+  return {
+    entries,
+    bySource: new Map(entries.map((entry) => [
+      profileSourceKey(entry.profile.source.repository, entry.profile.source.commit),
+      entry,
+    ])),
+    count: entries.length,
+  };
+}
+
+function profileForPair(profileIndex, pair) {
+  const snapshot = pair.sourceSnapshot;
+  const nwo = repoNwoFromArtifact(pair);
+  const commit = sourceSnapshotCommit(snapshot);
+  if (!nwo || !commit) return null;
+  return profileIndex.bySource.get(profileSourceKey(nwo, commit)) || null;
 }
 
 async function loadExistingSkillIndex(corexRoot) {
@@ -579,7 +697,86 @@ function buildEvidenceSummary(knowledgeArtifact, snapshot) {
   ].join(" ");
 }
 
+function markdownList(values) {
+  return toArray(values).map((value) => `- ${value}`);
+}
+
+function markdownNumberedList(values) {
+  return toArray(values).map((value, index) => `${index + 1}. ${value}`);
+}
+
+function firstRefMatching(candidate, pattern) {
+  return toArray(candidate?.provenance_references).find((ref) => pattern.test(String(ref || ""))) || null;
+}
+
 function draftSkillMarkdown(candidate) {
+  if (candidate.policy) {
+    const policy = candidate.policy;
+    const treeRef = firstRefMatching(candidate, /^github:[^:]+\/[^:]+:tree:/);
+    const evidenceRef = firstRefMatching(candidate, /^vega:evidence:/);
+    return [
+      `# ${candidate.name}`,
+      "",
+      "## Purpose",
+      policy.purpose,
+      "",
+      "## When to Use",
+      ...markdownList(policy.when_to_use),
+      "",
+      "## When Not to Use",
+      ...markdownList(policy.when_not_to_use),
+      "",
+      "## Relationship to Vega",
+      policy.relationship_to_vega,
+      "",
+      "## Safe Evaluation Workflow",
+      ...markdownNumberedList(policy.safe_evaluation_workflow),
+      "",
+      "## Immutable Provenance Requirements",
+      ...markdownList(policy.immutable_provenance_requirements),
+      "",
+      "## License Requirements",
+      ...markdownList(policy.license_requirements),
+      "",
+      "## Local-First Policy",
+      policy.local_first_policy,
+      "",
+      "## Network Restrictions",
+      ...markdownList(policy.network_restrictions),
+      "",
+      "## Credential Restrictions",
+      ...markdownList(policy.credential_restrictions),
+      "",
+      "## Human Approval Gates",
+      ...markdownList(policy.human_approval_gates),
+      "",
+      "## Allowed Outputs",
+      ...markdownList(policy.allowed_outputs),
+      "",
+      "## Failure and Refusal Conditions",
+      ...markdownList(policy.failure_conditions),
+      "",
+      "## Explicit Prohibitions",
+      ...markdownList(policy.prohibited_actions),
+      "",
+      "## Source Attribution",
+      ...markdownList(policy.source_attribution),
+      `- Candidate profile: ${candidate.candidate_profile?.profile_id || "unknown"}`,
+      `- Profile digest: ${candidate.candidate_profile?.profile_digest || "unknown"}`,
+      `- Repository: ${candidate.source_repository.nwo}`,
+      `- Source ref: ${candidate.source_snapshot_identity.source_ref}`,
+      `- Snapshot: ${candidate.source_snapshot_identity.snapshot_id}`,
+      treeRef ? `- Tree reference: ${treeRef}` : null,
+      evidenceRef ? `- Evidence reference: ${evidenceRef}` : null,
+      "",
+      "## Review Gate",
+      "- Status: pending",
+      "- This is a draft candidate only. Do not promote without human approval.",
+      "- This profile does not approve, install, execute, publish, or mutate Core-X state.",
+      "",
+    ].filter((line) => line !== null).join("\n");
+  }
+
   return [
     `# ${candidate.name}`,
     "",
@@ -604,21 +801,24 @@ function draftSkillMarkdown(candidate) {
   ].join("\n");
 }
 
-function buildCandidate({ pair, existingSkillIndex, existingCandidates, createdAt }) {
+function buildCandidate({ pair, existingSkillIndex, existingCandidates, profileEntry = null, createdAt }) {
   const snapshot = pair.sourceSnapshot;
   const knowledgeArtifact = pair.knowledgeArtifact;
   const nwo = repoNwoFromArtifact(pair);
   const safeRepo = slug(nwo);
-  const lane = inferLane(knowledgeArtifact, snapshot);
-  const scope = inferScope(snapshot, knowledgeArtifact);
+  const profile = profileEntry?.profile || null;
+  const lane = profile?.candidate?.lane || inferLane(knowledgeArtifact, snapshot);
+  const scope = profile?.candidate?.scope || inferScope(snapshot, knowledgeArtifact);
   const immutableSnapshot = isImmutableSourceSnapshot(snapshot);
   const license = licenseStatusFromSnapshot(snapshot) || licenseStatus(snapshot?.provenance?.license || snapshot?.metadata?.license || null);
-  const required = inferRequiredToolsAndServices(lane, knowledgeArtifact);
-  const suggestedSkillId = `vega-${safeRepo}`;
+  const required = profile?.candidate?.required_tools_services || inferRequiredToolsAndServices(lane, knowledgeArtifact);
+  const suggestedSkillId = profile?.candidate?.suggested_skill_id || `vega-${safeRepo}`;
   const provenanceReferences = unique([
     snapshot?.artifact_ref,
     `vega:data/repo-signals.json#${nwo}`,
     `vega:data/skill-extractions.json#${nwo}`,
+    profileEntry ? `vega:skill-candidate-profile:${profile.profile_id}:${profileEntry.profile_digest}` : null,
+    profileEntry ? profileEntry.profile_ref : null,
     ...toArray(snapshot?.provenance?.source_refs),
     ...toArray(snapshot?.provenance?.derived_from),
     snapshot?.provenance?.evidence_digest ? `vega:evidence:${snapshot.provenance.evidence_digest}` : null,
@@ -630,8 +830,8 @@ function buildCandidate({ pair, existingSkillIndex, existingCandidates, createdA
     schema_version: CANDIDATE_SCHEMA_VERSION,
     candidate_id: `vega.skill-candidate:${safeRepo}`,
     suggested_skill_id: suggestedSkillId,
-    name: `${snapshot?.metadata?.name || nwo} Core-X Skill Candidate`,
-    description: knowledgeArtifact?.summary || snapshot?.metadata?.description || `Review-gated skill candidate for ${nwo}.`,
+    name: profile?.candidate?.name || `${snapshot?.metadata?.name || nwo} Core-X Skill Candidate`,
+    description: profile?.candidate?.description || knowledgeArtifact?.summary || snapshot?.metadata?.description || `Review-gated skill candidate for ${nwo}.`,
     source_repository: {
       nwo,
       uri: snapshot?.source_uri || `https://github.com/${nwo}`,
@@ -648,7 +848,7 @@ function buildCandidate({ pair, existingSkillIndex, existingCandidates, createdA
     suggested_scope: scope,
     required_tools_services: required,
     license_status: license,
-    compatibility_assumptions: immutableSnapshot
+    compatibility_assumptions: profile?.candidate?.compatibility_assumptions || (immutableSnapshot
       ? [
         "Generated from Vega metadata plus a pinned immutable GitHub source snapshot.",
         "Candidate identity binds resolved commit, tree, README digest, license digest, consumed manifest digests, and aggregate evidence digest.",
@@ -659,8 +859,8 @@ function buildCandidate({ pair, existingSkillIndex, existingCandidates, createdA
         "Generated from Vega metadata, repo signals, and skill extraction cache only.",
         "No third-party source code or long README bodies are copied into this candidate.",
         "Promotion is blocked until a pinned immutable source snapshot is resolved.",
-      ],
-    evidence_summary: buildEvidenceSummary(knowledgeArtifact, snapshot),
+      ]),
+    evidence_summary: profile?.candidate?.evidence_summary || buildEvidenceSummary(knowledgeArtifact, snapshot),
     duplicate_matches: [],
     conflict_findings: [],
     risk_findings: [],
@@ -670,11 +870,38 @@ function buildCandidate({ pair, existingSkillIndex, existingCandidates, createdA
     tool: TOOL,
   };
 
+  if (profileEntry) {
+    base.candidate_profile = {
+      schema_version: PROFILE_SCHEMA_VERSION,
+      profile_id: profile.profile_id,
+      profile_ref: profileEntry.profile_ref,
+      profile_digest: profileEntry.profile_digest,
+      source: {
+        repository: profile.source.repository,
+        commit: profile.source.commit,
+      },
+      runtime: profile.candidate.runtime,
+    };
+    base.policy = profile.policy;
+  }
+
   base.duplicate_matches = duplicateMatches(base, existingSkillIndex, existingCandidates);
+  base.duplicate_matches = unique([
+    ...base.duplicate_matches.map((match) => stableStringify(match)),
+    ...toArray(profile?.candidate?.duplicate_matches).map((match) => stableStringify(match)),
+  ]).map((match) => JSON.parse(match));
   base.__sourceSnapshot = snapshot;
   base.conflict_findings = conflictFindings(base, knowledgeArtifact, existingSkillIndex);
+  base.conflict_findings = [
+    ...base.conflict_findings,
+    ...toArray(profile?.candidate?.conflict_findings),
+  ];
   delete base.__sourceSnapshot;
   base.risk_findings = riskFindings(base, knowledgeArtifact);
+  base.risk_findings = [
+    ...base.risk_findings,
+    ...toArray(profile?.candidate?.risk_findings),
+  ];
   base.content_checksum = candidateContentChecksum(base);
   base.draft_skill_md = draftSkillMarkdown(base);
   return base;
@@ -703,6 +930,19 @@ export function validateSkillCandidate(candidate) {
   }
   if (candidate?.source_repository?.private === true && candidate?.visibility === "public") {
     blockers.push({ kind: "privacy", severity: "blocking", summary: "Private repository candidates cannot be public." });
+  }
+  if (candidate?.candidate_profile) {
+    const profileRepo = String(candidate.candidate_profile.source?.repository || "").toLowerCase();
+    const candidateRepo = String(candidate.source_repository?.nwo || "").toLowerCase();
+    const profileCommit = String(candidate.candidate_profile.source?.commit || "").toLowerCase();
+    const sourceRef = String(candidate.source_snapshot_identity?.source_ref || "").toLowerCase();
+    if (profileRepo !== candidateRepo || !sourceRef.endsWith(`@${profileCommit}`)) {
+      blockers.push({
+        kind: "profile_source_binding",
+        severity: "blocking",
+        summary: "Candidate profile source binding does not match candidate repository and immutable source snapshot.",
+      });
+    }
   }
 
   return {
@@ -837,10 +1077,12 @@ export async function buildSkillCandidateIngestion(options = {}) {
   });
   const existingSkillIndex = await loadExistingSkillIndex(corexRoot);
   const existingCandidates = await loadExistingCandidates(root, outDir);
+  const profileIndex = await loadSkillCandidateProfiles(root);
   const candidates = contractResult.artifacts.map((pair) => buildCandidate({
     pair,
     existingSkillIndex,
     existingCandidates,
+    profileEntry: profileForPair(profileIndex, pair),
     createdAt,
   }));
   const proposals = candidates.map((candidate) => buildPromotionProposal(candidate, { createdAt }));
@@ -863,6 +1105,7 @@ export async function buildSkillCandidateIngestion(options = {}) {
       corex_skill_index_available: existingSkillIndex.available,
       existing_skill_count: existingSkillIndex.skillRecords.length,
       existing_candidate_count: existingCandidates.length,
+      skill_candidate_profile_count: profileIndex.count,
     },
   };
 }
@@ -932,6 +1175,8 @@ export async function runBuildSkillCandidates(argv = process.argv.slice(2)) {
       duplicate_matches: candidate.duplicate_matches.length,
       conflict_findings: candidate.conflict_findings.length,
       risk_findings: candidate.risk_findings.length,
+      profile_id: candidate.candidate_profile?.profile_id || null,
+      profile_digest: candidate.candidate_profile?.profile_digest || null,
       review_status: candidate.review_status,
       content_checksum: candidate.content_checksum,
     })),

--- a/src/lib/action-bridge.ts
+++ b/src/lib/action-bridge.ts
@@ -195,14 +195,30 @@ function summarizeValue(value: unknown): string {
       suggested_skill_id?: string;
       evidence_summary?: string;
       review_status?: string;
+      candidate_profile?: {
+        profile_id?: string;
+        profile_digest?: string;
+        source?: {
+          repository?: string;
+          commit?: string;
+        };
+      };
     };
+    const profile = candidate.candidate_profile;
     return [
       `Candidate: ${candidate.candidate_id}`,
       `Suggested skill: ${candidate.suggested_skill_id}`,
+      profile?.profile_id
+        ? `Curated candidate profile: ${profile.profile_id}`
+        : "Candidate kind: Generic candidate",
+      profile?.profile_digest ? `Profile digest: ${profile.profile_digest}` : null,
+      profile?.source?.repository && profile?.source?.commit
+        ? `Profile source: ${profile.source.repository}@${profile.source.commit}`
+        : null,
       `Review: ${candidate.review_status || "pending"}`,
       "",
       candidate.evidence_summary || "",
-    ].join("\n");
+    ].filter(Boolean).join("\n");
   }
 
   return `\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\``;

--- a/src/server/action-bridge.js
+++ b/src/server/action-bridge.js
@@ -570,6 +570,15 @@ async function runDossier(root, request, run) {
   const snapshot = candidate.source_snapshot_identity?.artifact_ref
     ? await readJson(path.join(root, candidate.source_snapshot_identity.artifact_ref), null)
     : null;
+  const profile = candidate.candidate_profile || null;
+  const profileSummaryLines = profile
+    ? [
+      `- Candidate kind: curated profile`,
+      `- Profile id: ${profile.profile_id}`,
+      `- Profile digest: ${profile.profile_digest}`,
+      `- Profile source: ${profile.source.repository}@${profile.source.commit}`,
+    ]
+    : ["- Candidate kind: generic"];
 
   const files = [
     ["00-DECISION-SUMMARY.md", [
@@ -577,6 +586,7 @@ async function runDossier(root, request, run) {
       "",
       `- Candidate: ${candidate.candidate_id}`,
       `- Suggested skill: ${candidate.suggested_skill_id}`,
+      ...profileSummaryLines,
       `- Review state: pending`,
       `- Visibility: internal`,
       `- Validation: ${validation.valid ? "valid" : "blocked"}`,
@@ -598,6 +608,9 @@ async function runDossier(root, request, run) {
       `# Evidence: ${candidate.name}`,
       "",
       candidate.evidence_summary,
+      "",
+      "## Candidate Profile",
+      ...profileSummaryLines,
       "",
       "## Provenance",
       ...candidate.provenance_references.map((ref) => `- ${ref}`),

--- a/tests/test-skill-candidate-profiles.js
+++ b/tests/test-skill-candidate-profiles.js
@@ -1,0 +1,372 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  buildSkillCandidateIngestion,
+  candidateContentChecksum,
+  validateSkillCandidate,
+} from "../scripts/build-skill-candidates.js";
+import {
+  buildSourceSnapshotFromEvidence,
+  stablePrettyStringify,
+} from "../scripts/source-snapshot-resolver.js";
+
+const COMMIT_A = "a".repeat(40);
+const COMMIT_B = "b".repeat(40);
+const TREE_A = "c".repeat(40);
+const TREE_B = "d".repeat(40);
+const PROFILE_SCHEMA_SRC = new URL("../config/skill-candidate-profiles/schema.json", import.meta.url);
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+async function writeJson(filePath, data) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+}
+
+async function writeProfileSchema(projectRoot) {
+  const target = path.join(projectRoot, "config", "skill-candidate-profiles", "schema.json");
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.copyFile(PROFILE_SCHEMA_SRC, target);
+}
+
+async function writeProfile(projectRoot, profile, name = `${profile.profile_id}.json`) {
+  await writeProfileSchema(projectRoot);
+  await writeJson(path.join(projectRoot, "config", "skill-candidate-profiles", name), profile);
+}
+
+async function seedVegaCaches(projectRoot, repo) {
+  await writeJson(path.join(projectRoot, "data", "data.json"), [repo]);
+  await writeJson(path.join(projectRoot, "data", "my-repos.json"), []);
+  await writeJson(path.join(projectRoot, "data", "repo-signals.json"), [{
+    nwo: "example/agent-toolkit",
+    description: repo.description,
+    adoptionScore: 88,
+    adoptionKind: "tool",
+    capabilities: ["agent-workflows", "developer-tooling"],
+    houseSkills: ["skill-extraction"],
+  }]);
+  await writeJson(path.join(projectRoot, "data", "skill-extractions.json"), [{
+    nwo: "example/agent-toolkit",
+    summary: "Reusable MCP agent workflow primitives.",
+    capabilities: ["agent-workflows"],
+    houseSkills: ["skill-extraction"],
+    flows: ["research-queue-flow"],
+    adoptionKind: "tool",
+  }]);
+}
+
+async function writeImmutableSnapshot(projectRoot, repo, { commitSha = COMMIT_A, treeSha = TREE_A } = {}) {
+  const snapshot = buildSourceSnapshotFromEvidence({
+    repository: repo,
+    githubRepo: {
+      default_branch: "main",
+      description: repo.description,
+      language: repo.primary_language,
+      license: { spdx_id: repo.license },
+      topics: repo.topics,
+      private: false,
+    },
+    requestedRef: "main",
+    refType: "branch",
+    commit: {
+      sha: commitSha,
+      tree_sha: treeSha,
+      committed_at: "2026-06-12T00:00:00.000Z",
+    },
+    tree: {
+      sha: treeSha,
+      truncated: false,
+    },
+    evidence: [
+      {
+        kind: "readme",
+        path: "README.md",
+        blob_sha: "e".repeat(40),
+        content_sha256: "sha256:35a528211dbf54569e622969c569685ea27156d37373637c4751ded08e9d3f4e",
+        size: 52,
+        text_preview: "# Agent Toolkit\n\nDeterministic agent workflow toolkit.",
+      },
+      {
+        kind: "license",
+        path: "LICENSE",
+        blob_sha: "f".repeat(40),
+        content_sha256: "sha256:2c73f0eec270c48d35dbe2f0b742d3a45eb1fda715d9c98a5d271610000784f7",
+        size: 38,
+        text_preview: "MIT License\n\nPermission is hereby granted...",
+      },
+      {
+        kind: "manifest",
+        path: "package.json",
+        blob_sha: "1".repeat(40),
+        content_sha256: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        size: 28,
+        text_preview: "{\"name\":\"agent-toolkit\"}",
+      },
+    ],
+  });
+  const snapshotPath = path.join(projectRoot, snapshot.artifact_ref);
+  await fs.mkdir(path.dirname(snapshotPath), { recursive: true });
+  await fs.writeFile(snapshotPath, stablePrettyStringify(snapshot), "utf8");
+  await writeJson(path.join(projectRoot, "data", "review", "source-snapshots", "index.json"), {
+    entries: {
+      "example/agent-toolkit": {
+        nwo: "example/agent-toolkit",
+        artifact_ref: snapshot.artifact_ref,
+        snapshot_id: snapshot.id,
+        resolved_commit_sha: snapshot.metadata.immutable.resolved_commit_sha,
+        resolved_tree_sha: snapshot.metadata.immutable.resolved_tree_sha,
+        evidence_contract_version: snapshot.metadata.immutable.evidence_contract_version,
+        evidence_digest: snapshot.metadata.immutable.evidence_digest,
+      },
+    },
+  });
+  return snapshot;
+}
+
+function profileFixture(overrides = {}) {
+  const profile = {
+    schema_version: "vega.skill-candidate-profile.v1",
+    profile_id: "agent-toolkit-ingestion-review",
+    source: {
+      repository: "example/agent-toolkit",
+      commit: COMMIT_A,
+    },
+    candidate: {
+      suggested_skill_id: "agent-toolkit-ingestion-review",
+      name: "Agent Toolkit Ingestion Review",
+      description: "Reference and governance skill for reviewing external agent workflow systems without executing upstream runtime flows.",
+      lane: "agent-workflows",
+      scope: "shared",
+      runtime: "markdown-prompt",
+      required_tools_services: {
+        tools: ["vega-lab:source-snapshot", "vega-lab:skill-candidates"],
+        services: [],
+      },
+      compatibility_assumptions: [
+        "Reference and governance markdown only; no upstream code execution is part of this candidate.",
+        "Candidate relies on pinned Vega source snapshot evidence.",
+      ],
+      evidence_summary: "Pinned evidence shows an agent workflow toolkit. The safe Core-X use is a governance and reference checklist.",
+      duplicate_matches: [],
+      conflict_findings: [{
+        kind: "runtime-scope",
+        severity: "warning",
+        summary: "Executable integration is out of scope for this candidate.",
+        source_refs: ["README.md"],
+      }],
+      risk_findings: [{
+        kind: "runtime-adapter-review",
+        severity: "warning",
+        summary: "Runtime adapter work requires separate review.",
+        source_refs: ["package.json"],
+      }],
+    },
+    policy: {
+      purpose: "Use this skill as a Core-X review guide for evaluating external agent workflow systems.",
+      when_to_use: [
+        "Review pinned source evidence for agent workflow patterns.",
+        "Draft bounded review notes with provenance.",
+      ],
+      when_not_to_use: [
+        "Do not run upstream commands.",
+        "Do not mutate Core-X registries.",
+      ],
+      relationship_to_vega: "Vega remains the evaluator and review layer. The upstream repository is reference material only.",
+      safe_evaluation_workflow: [
+        "Confirm immutable source snapshot identity.",
+        "Inspect pinned evidence only.",
+        "Produce a pending review note.",
+        "Stop before install, apply, publish, upload, service start, credential use, or registry mutation.",
+      ],
+      immutable_provenance_requirements: [
+        "Repository must be example/agent-toolkit.",
+        `Commit must be ${COMMIT_A}.`,
+      ],
+      license_requirements: [
+        "License evidence must come from the pinned source snapshot.",
+      ],
+      local_first_policy: "Default to offline review of pinned evidence.",
+      network_restrictions: [
+        "Do not fetch or scrape through the upstream runtime.",
+      ],
+      credential_restrictions: [
+        "Do not request, echo, store, or infer credentials.",
+      ],
+      human_approval_gates: [
+        "Human review is required before approving the candidate.",
+      ],
+      allowed_outputs: [
+        "Reference checklist",
+        "Risk findings",
+      ],
+      failure_conditions: [
+        "Source repository or commit does not match the pinned profile.",
+      ],
+      prohibited_actions: [
+        "Install upstream dependencies.",
+        "Run upstream CLI commands.",
+        "Mutate Core-X registries.",
+      ],
+      source_attribution: [
+        "Repository: example/agent-toolkit",
+        `Commit: ${COMMIT_A}`,
+      ],
+    },
+  };
+  return { ...profile, ...overrides };
+}
+
+async function buildFirstCandidate(projectRoot, corexRoot) {
+  const result = await buildSkillCandidateIngestion({
+    projectRoot,
+    corexRoot,
+    outDir: path.join(projectRoot, "data", "review"),
+    dryRun: true,
+    limit: 1,
+    createdAt: "2026-06-13T00:00:00.000Z",
+  });
+  assert.equal(result.candidates.length, 1);
+  return { result, candidate: result.candidates[0] };
+}
+
+async function withFixture(callback) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "vega-skill-profile-"));
+  const projectRoot = path.join(root, "vega-lab");
+  const corexRoot = path.join(root, "core-x");
+  const repo = {
+    name: "agent-toolkit",
+    author: "example",
+    description: "A deterministic agent workflow toolkit.",
+    url: "https://github.com/example/agent-toolkit",
+    stars: 700,
+    forks: 40,
+    primary_language: "TypeScript",
+    topics: ["agent", "workflow", "mcp"],
+    license: "MIT",
+  };
+  try {
+    await seedVegaCaches(projectRoot, repo);
+    await fs.mkdir(path.join(corexRoot, "skills"), { recursive: true });
+    await writeImmutableSnapshot(projectRoot, repo);
+    await callback({ root, projectRoot, corexRoot, repo });
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
+async function assertRejectsCode(promise, code) {
+  await assert.rejects(promise, (error) => {
+    assert.equal(error.code, code);
+    return true;
+  });
+}
+
+async function main() {
+  await withFixture(async ({ projectRoot, corexRoot }) => {
+    const { result, candidate } = await buildFirstCandidate(projectRoot, corexRoot);
+    assert.equal(result.checks.skill_candidate_profile_count, 0);
+    assert.equal(candidate.suggested_skill_id, "vega-example-agent-toolkit");
+    assert.equal(candidate.candidate_profile, undefined);
+    assert.equal(candidate.policy, undefined);
+    assert.equal(validateSkillCandidate(candidate).valid, true);
+  });
+
+  await withFixture(async ({ projectRoot, corexRoot }) => {
+    await writeProfile(projectRoot, profileFixture());
+    const { result, candidate } = await buildFirstCandidate(projectRoot, corexRoot);
+    assert.equal(result.checks.skill_candidate_profile_count, 1);
+    assert.equal(candidate.candidate_id, "vega.skill-candidate:example-agent-toolkit");
+    assert.equal(candidate.suggested_skill_id, "agent-toolkit-ingestion-review");
+    assert.equal(candidate.name, "Agent Toolkit Ingestion Review");
+    assert.equal(candidate.candidate_profile.profile_id, "agent-toolkit-ingestion-review");
+    assert.match(candidate.candidate_profile.profile_digest, /^sha256:[a-f0-9]{64}$/);
+    assert.ok(candidate.provenance_references.some((ref) => ref.startsWith("vega:skill-candidate-profile:agent-toolkit-ingestion-review:sha256:")));
+    assert.equal(candidate.policy.relationship_to_vega.includes("Vega remains the evaluator"), true);
+    assert.match(candidate.draft_skill_md, /## Explicit Prohibitions/);
+    assert.match(candidate.draft_skill_md, /## Source Attribution/);
+    assert.equal(candidate.content_checksum, candidateContentChecksum(candidate));
+    assert.equal(validateSkillCandidate(candidate).valid, true);
+
+    const tamperedDigest = clone(candidate);
+    tamperedDigest.candidate_profile.profile_digest = `sha256:${"0".repeat(64)}`;
+    const tamperedDigestValidation = validateSkillCandidate(tamperedDigest);
+    assert.equal(tamperedDigestValidation.valid, false);
+    assert.ok(tamperedDigestValidation.blockers.some((blocker) => blocker.kind === "checksum"));
+
+    const tamperedSource = clone(candidate);
+    tamperedSource.candidate_profile.source.commit = COMMIT_B;
+    tamperedSource.content_checksum = candidateContentChecksum(tamperedSource);
+    const tamperedSourceValidation = validateSkillCandidate(tamperedSource);
+    assert.equal(tamperedSourceValidation.valid, false);
+    assert.ok(tamperedSourceValidation.blockers.some((blocker) => blocker.kind === "profile_source_binding"));
+  });
+
+  await withFixture(async ({ projectRoot, corexRoot }) => {
+    const profile = profileFixture();
+    await writeProfile(projectRoot, profile);
+    const first = await buildFirstCandidate(projectRoot, corexRoot);
+    const firstChecksum = first.candidate.content_checksum;
+    const firstDigest = first.candidate.candidate_profile.profile_digest;
+
+    const changedProfile = clone(profile);
+    changedProfile.policy.purpose = "Changed profile purpose for deterministic checksum coverage.";
+    await writeProfile(projectRoot, changedProfile);
+    const second = await buildFirstCandidate(projectRoot, corexRoot);
+    assert.notEqual(second.candidate.candidate_profile.profile_digest, firstDigest);
+    assert.notEqual(second.candidate.content_checksum, firstChecksum);
+  });
+
+  await withFixture(async ({ projectRoot, corexRoot, repo }) => {
+    await writeProfile(projectRoot, profileFixture());
+    await writeImmutableSnapshot(projectRoot, repo, { commitSha: COMMIT_B, treeSha: TREE_B });
+    const { result, candidate } = await buildFirstCandidate(projectRoot, corexRoot);
+    assert.equal(result.checks.skill_candidate_profile_count, 1);
+    assert.equal(candidate.suggested_skill_id, "vega-example-agent-toolkit");
+    assert.equal(candidate.candidate_profile, undefined);
+  });
+
+  await withFixture(async ({ projectRoot, corexRoot }) => {
+    const invalid = profileFixture();
+    delete invalid.policy;
+    await writeProfile(projectRoot, invalid);
+    await assertRejectsCode(buildFirstCandidate(projectRoot, corexRoot), "invalid_skill_candidate_profile");
+  });
+
+  await withFixture(async ({ projectRoot, corexRoot }) => {
+    const first = profileFixture();
+    const second = profileFixture({
+      source: { repository: "example/agent-toolkit", commit: COMMIT_B },
+      candidate: {
+        ...profileFixture().candidate,
+        suggested_skill_id: "agent-toolkit-ingestion-review-b",
+      },
+    });
+    await writeProfile(projectRoot, first, "first.json");
+    await writeProfile(projectRoot, second, "second.json");
+    await assertRejectsCode(buildFirstCandidate(projectRoot, corexRoot), "invalid_skill_candidate_profile");
+  });
+
+  await withFixture(async ({ projectRoot, corexRoot }) => {
+    const first = profileFixture();
+    const second = profileFixture({
+      profile_id: "agent-toolkit-ingestion-review-b",
+      source: { repository: "example/agent-toolkit", commit: COMMIT_B },
+    });
+    await writeProfile(projectRoot, first, "first.json");
+    await writeProfile(projectRoot, second, "second.json");
+    await assertRejectsCode(buildFirstCandidate(projectRoot, corexRoot), "invalid_skill_candidate_profile");
+  });
+}
+
+main().catch((error) => {
+  console.error("Skill candidate profile test failed");
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary\n- Adds tracked, schema-validated Vega skill candidate profiles.\n- Adds a curated Skill Seekers ingestion-review profile bound to yusufkaraaslan/Skill_Seekers@61911d0efa72ae506acf7242f4775a9ddc6a3466.\n- Compiles profile policy into canonical Core-X skill candidate fields with profile digest provenance and checksum coverage.\n- Keeps generic repositories on the existing generic candidate path.\n- Shows curated/generic candidate type, profile digest, and source binding in durable action surfaces.\n\n## Dependency\n- Depends on Core-X PR #21 for canonical Core-X profile/policy schema acceptance and deterministic profile-backed SKILL.md rendering.\n\n## Reproduction\n- Resolved pinned Skill Seekers source snapshot twice with GitHub token variables unset.\n- Both write-mode builds produced byte-identical candidate JSON and SKILL.md artifacts.\n- New candidate checksum: sha256:94a3257efa412b1f8dc256f27f2f488a358606f095fef5377a8dfdb2ca4a9617\n- Profile digest: sha256:f02d35fab992844e3275fd4544a91860b0dd632cefa0db991943ba6e98eee698\n\n## Verification\n- npm run test:skill-candidate-ingestion\n- npm run test:source-snapshots\n- npm run test:action-bridge\n- npm run test:mcp\n- npm run test:corex-contract-export\n- npm test\n- npm run build\n- npm run export:corex-contracts -- --dry-run --limit=2\n- node --check scripts/build-skill-candidates.js\n- node --check tests/test-skill-candidate-profiles.js\n\nNo candidate approval, approved review, proposal approval, Core-X apply, registry mutation, or generated review packet is included.